### PR TITLE
Automatic update of FluentValidation.DependencyInjectionExtensions to 11.8.0

### DIFF
--- a/HomeBudget.Rates.Api/HomeBudget.Rates.Api.csproj
+++ b/HomeBudget.Rates.Api/HomeBudget.Rates.Api.csproj
@@ -16,7 +16,7 @@
     <PackageReference Include="AutoMapper.Extensions.Microsoft.DependencyInjection" Version="12.0.1" />
     <PackageReference Include="Datadog.Trace.Bundle" Version="2.39.0" />
     <PackageReference Include="FluentValidation.AspNetCore" Version="11.3.0" />
-    <PackageReference Include="FluentValidation.DependencyInjectionExtensions" Version="11.7.1" />
+    <PackageReference Include="FluentValidation.DependencyInjectionExtensions" Version="11.8.0" />
     <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.19.5" />
     <PackageReference Include="Serilog.AspNetCore" Version="7.0.0" />
     <PackageReference Include="Serilog.Enrichers.Environment" Version="2.3.0" />


### PR DESCRIPTION
NuKeeper has generated a minor update of `FluentValidation.DependencyInjectionExtensions` to `11.8.0` from `11.7.1`
`FluentValidation.DependencyInjectionExtensions 11.8.0` was published at `2023-10-19T12:12:28Z`, 9 days ago

1 project update:
Updated `HomeBudget.Rates.Api/HomeBudget.Rates.Api.csproj` to `FluentValidation.DependencyInjectionExtensions` `11.8.0` from `11.7.1`

[FluentValidation.DependencyInjectionExtensions 11.8.0 on NuGet.org](https://www.nuget.org/packages/FluentValidation.DependencyInjectionExtensions/11.8.0)


This is an automated update. Merge only if it passes tests
**NuKeeper**: https://github.com/NuKeeperDotNet/NuKeeper
