### PR TITLE
Automatic update of Dapper to 2.1.15

### DIFF
--- a/HomeBudget.DataAccess.Dapper/HomeBudget.DataAccess.Dapper.csproj
+++ b/HomeBudget.DataAccess.Dapper/HomeBudget.DataAccess.Dapper.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Dapper" Version="2.1.11" />
+    <PackageReference Include="Dapper" Version="2.1.15" />
     <PackageReference Include="Microsoft.Data.SqlClient" Version="5.1.1" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="7.0.1" />
     <PackageReference Include="Microsoft.Extensions.Options" Version="7.0.1" />


### PR DESCRIPTION
NuKeeper has generated a patch update of `Dapper` to `2.1.15` from `2.1.11`
`Dapper 2.1.15` was published at `2023-10-19T12:51:49Z`, 9 days ago

1 project update:
Updated `HomeBudget.DataAccess.Dapper/HomeBudget.DataAccess.Dapper.csproj` to `Dapper` `2.1.15` from `2.1.11`

[Dapper 2.1.15 on NuGet.org](https://www.nuget.org/packages/Dapper/2.1.15)


This is an automated update. Merge only if it passes tests
**NuKeeper**: https://github.com/NuKeeperDotNet/NuKeeper
