### PR TITLE
Automatic update of Microsoft.Extensions.Http.Polly to 7.0.13

### DIFF
--- a/HomeBudget.Components.CurrencyRates/HomeBudget.Components.CurrencyRates.csproj
+++ b/HomeBudget.Components.CurrencyRates/HomeBudget.Components.CurrencyRates.csproj
@@ -11,7 +11,7 @@
 		<PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="7.0.0" />
 		<PackageReference Include="Microsoft.Extensions.Http" Version="7.0.0" />
 		<PackageReference Include="Polly" Version="8.0.0" />
-		<PackageReference Include="Microsoft.Extensions.Http.Polly" Version="7.0.12" />
+		<PackageReference Include="Microsoft.Extensions.Http.Polly" Version="7.0.13" />
 		<PackageReference Include="Polly.Extensions.Http" Version="3.0.0" />
 		<PackageReference Include="Refit.Newtonsoft.Json" Version="7.0.0" />
 		<PackageReference Include="Refit.HttpClientFactory" Version="7.0.0" />


### PR DESCRIPTION
NuKeeper has generated a patch update of `Microsoft.Extensions.Http.Polly` to `7.0.13` from `7.0.12`
`Microsoft.Extensions.Http.Polly 7.0.13` was published at `2023-10-24T11:42:05Z`, 7 days ago

1 project update:
Updated `HomeBudget.Components.CurrencyRates/HomeBudget.Components.CurrencyRates.csproj` to `Microsoft.Extensions.Http.Polly` `7.0.13` from `7.0.12`

[Microsoft.Extensions.Http.Polly 7.0.13 on NuGet.org](https://www.nuget.org/packages/Microsoft.Extensions.Http.Polly/7.0.13)


This is an automated update. Merge only if it passes tests
**NuKeeper**: https://github.com/NuKeeperDotNet/NuKeeper
