### PR TITLE
Automatic update of StackExchange.Redis to 2.7.4

### DIFF
--- a/HomeBudget.Core/HomeBudget.Core.csproj
+++ b/HomeBudget.Core/HomeBudget.Core.csproj
@@ -8,7 +8,7 @@
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="7.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="7.0.1" />
     <PackageReference Include="Microsoft.Extensions.Options" Version="7.0.1" />
-    <PackageReference Include="StackExchange.Redis" Version="2.6.122" />
+    <PackageReference Include="StackExchange.Redis" Version="2.7.4" />
   </ItemGroup>
 
   <ItemGroup>

--- a/HomeBudget.Rates.Api/HomeBudget.Rates.Api.csproj
+++ b/HomeBudget.Rates.Api/HomeBudget.Rates.Api.csproj
@@ -26,7 +26,7 @@
     <PackageReference Include="Serilog.Extensions.Logging" Version="7.0.0" />
     <PackageReference Include="Serilog.Formatting.Compact" Version="1.1.0" />
     <PackageReference Include="Serilog.Sinks.Debug" Version="2.0.0" />
-    <PackageReference Include="StackExchange.Redis" Version="2.6.122" />
+    <PackageReference Include="StackExchange.Redis" Version="2.7.4" />
     <PackageReference Include="Serilog.Sinks.Elasticsearch" Version="9.0.3" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />
   </ItemGroup>


### PR DESCRIPTION
NuKeeper has generated a minor update of `StackExchange.Redis` to `2.7.4` from `2.6.122`
`StackExchange.Redis 2.7.4` was published at `2023-10-31T14:58:53Z`, 11 days ago

2 project updates:
Updated `HomeBudget.Core/HomeBudget.Core.csproj` to `StackExchange.Redis` `2.7.4` from `2.6.122`
Updated `HomeBudget.Rates.Api/HomeBudget.Rates.Api.csproj` to `StackExchange.Redis` `2.7.4` from `2.6.122`

[StackExchange.Redis 2.7.4 on NuGet.org](https://www.nuget.org/packages/StackExchange.Redis/2.7.4)


This is an automated update. Merge only if it passes tests
**NuKeeper**: https://github.com/NuKeeperDotNet/NuKeeper
