### PR TITLE
Automatic update of Polly to 8.1.0

### DIFF
--- a/HomeBudget.Components.CurrencyRates/HomeBudget.Components.CurrencyRates.csproj
+++ b/HomeBudget.Components.CurrencyRates/HomeBudget.Components.CurrencyRates.csproj
@@ -10,7 +10,7 @@
 		<PackageReference Include="MediatR" Version="12.1.1" />
 		<PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="7.0.0" />
 		<PackageReference Include="Microsoft.Extensions.Http" Version="7.0.0" />
-		<PackageReference Include="Polly" Version="8.0.0" />
+		<PackageReference Include="Polly" Version="8.1.0" />
 		<PackageReference Include="Microsoft.Extensions.Http.Polly" Version="7.0.13" />
 		<PackageReference Include="Polly.Extensions.Http" Version="3.0.0" />
 		<PackageReference Include="Refit.Newtonsoft.Json" Version="7.0.0" />


### PR DESCRIPTION
NuKeeper has generated a minor update of `Polly` to `8.1.0` from `8.0.0`
`Polly 8.1.0` was published at `2023-10-31T17:34:22Z`, 11 days ago

1 project update:
Updated `HomeBudget.Components.CurrencyRates/HomeBudget.Components.CurrencyRates.csproj` to `Polly` `8.1.0` from `8.0.0`

[Polly 8.1.0 on NuGet.org](https://www.nuget.org/packages/Polly/8.1.0)


This is an automated update. Merge only if it passes tests
**NuKeeper**: https://github.com/NuKeeperDotNet/NuKeeper
