### PR TITLE
Automatic update of Dapper to 2.1.28

### DIFF
--- a/HomeBudget.DataAccess.Dapper/HomeBudget.DataAccess.Dapper.csproj
+++ b/HomeBudget.DataAccess.Dapper/HomeBudget.DataAccess.Dapper.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Dapper" Version="2.1.24" />
+    <PackageReference Include="Dapper" Version="2.1.28" />
     <PackageReference Include="Microsoft.Data.SqlClient" Version="5.1.2" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.0" />
     <PackageReference Include="Microsoft.Extensions.Options" Version="8.0.0" />


### PR DESCRIPTION
NuKeeper has generated a patch update of `Dapper` to `2.1.28` from `2.1.24`
`Dapper 2.1.28` was published at `2024-01-02T16:11:54Z`, 11 days ago

1 project update:
Updated `HomeBudget.DataAccess.Dapper/HomeBudget.DataAccess.Dapper.csproj` to `Dapper` `2.1.28` from `2.1.24`

[Dapper 2.1.28 on NuGet.org](https://www.nuget.org/packages/Dapper/2.1.28)


This is an automated update. Merge only if it passes tests
**NuKeeper**: https://github.com/NuKeeperDotNet/NuKeeper
