### PR TITLE
Automatic update of Microsoft.VisualStudio.Azure.Containers.Tools.Targets to 1.19.6

### DIFF
--- a/HomeBudget.Rates.Api/HomeBudget.Rates.Api.csproj
+++ b/HomeBudget.Rates.Api/HomeBudget.Rates.Api.csproj
@@ -18,7 +18,7 @@
     <PackageReference Include="Datadog.Trace.Bundle" Version="2.44.0" />
     <PackageReference Include="FluentValidation.AspNetCore" Version="11.3.0" />
     <PackageReference Include="FluentValidation.DependencyInjectionExtensions" Version="11.9.0" />
-    <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.19.5" />
+    <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.19.6" />
     <PackageReference Include="Serilog.AspNetCore" Version="8.0.0" />
     <PackageReference Include="Serilog.Enrichers.Environment" Version="2.3.0" />
     <PackageReference Include="Serilog.Enrichers.Span" Version="3.1.0" />


### PR DESCRIPTION
NuKeeper has generated a patch update of `Microsoft.VisualStudio.Azure.Containers.Tools.Targets` to `1.19.6` from `1.19.5`
`Microsoft.VisualStudio.Azure.Containers.Tools.Targets 1.19.6` was published at `2024-01-05T20:06:04Z`, 8 days ago

1 project update:
Updated `HomeBudget.Rates.Api/HomeBudget.Rates.Api.csproj` to `Microsoft.VisualStudio.Azure.Containers.Tools.Targets` `1.19.6` from `1.19.5`

[Microsoft.VisualStudio.Azure.Containers.Tools.Targets 1.19.6 on NuGet.org](https://www.nuget.org/packages/Microsoft.VisualStudio.Azure.Containers.Tools.Targets/1.19.6)


This is an automated update. Merge only if it passes tests
**NuKeeper**: https://github.com/NuKeeperDotNet/NuKeeper
