### PR TITLE
Automatic update of SonarAnalyzer.CSharp to 9.17.0.82934

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -5,6 +5,6 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.118" PrivateAssets="all" Condition="$(MSBuildProjectExtension) == '.csproj'" />
-    <PackageReference Include="SonarAnalyzer.CSharp" Version="9.16.0.82469" PrivateAssets="all" Condition="$(MSBuildProjectExtension) == '.csproj'" />
+    <PackageReference Include="SonarAnalyzer.CSharp" Version="9.17.0.82934" PrivateAssets="all" Condition="$(MSBuildProjectExtension) == '.csproj'" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
NuKeeper has generated a minor update of `SonarAnalyzer.CSharp` to `9.17.0.82934` from `9.16.0.82469`
`SonarAnalyzer.CSharp 9.17.0.82934` was published at `2024-01-17T10:06:34Z`, 7 days ago

1 project update:
Updated `Directory.Build.props` to `SonarAnalyzer.CSharp` `9.17.0.82934` from `9.16.0.82469`

[SonarAnalyzer.CSharp 9.17.0.82934 on NuGet.org](https://www.nuget.org/packages/SonarAnalyzer.CSharp/9.17.0.82934)


This is an automated update. Merge only if it passes tests
**NuKeeper**: https://github.com/NuKeeperDotNet/NuKeeper
