### PR TITLE
Automatic update of Microsoft.Data.SqlClient to 5.1.5

### DIFF
--- a/HomeBudget.DataAccess.Dapper/HomeBudget.DataAccess.Dapper.csproj
+++ b/HomeBudget.DataAccess.Dapper/HomeBudget.DataAccess.Dapper.csproj
@@ -8,7 +8,7 @@
 
   <ItemGroup>
     <PackageReference Include="Dapper" Version="2.1.28" />
-    <PackageReference Include="Microsoft.Data.SqlClient" Version="5.1.4" />
+    <PackageReference Include="Microsoft.Data.SqlClient" Version="5.1.5" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.0" />
     <PackageReference Include="Microsoft.Extensions.Options" Version="8.0.1" />
   </ItemGroup>


### PR DESCRIPTION
NuKeeper has generated a patch update of `Microsoft.Data.SqlClient` to `5.1.5` from `5.1.4`
`Microsoft.Data.SqlClient 5.1.5` was published at `2024-01-29T16:04:04Z`, 7 days ago

1 project update:
Updated `HomeBudget.DataAccess.Dapper/HomeBudget.DataAccess.Dapper.csproj` to `Microsoft.Data.SqlClient` `5.1.5` from `5.1.4`

[Microsoft.Data.SqlClient 5.1.5 on NuGet.org](https://www.nuget.org/packages/Microsoft.Data.SqlClient/5.1.5)


This is an automated update. Merge only if it passes tests
**NuKeeper**: https://github.com/NuKeeperDotNet/NuKeeper
