### PR TITLE
Automatic update of NUnit.Analyzers to 4.0.1

### DIFF
--- a/HomeBudget.Components.IntegrationTests/HomeBudget.Components.IntegrationTests.csproj
+++ b/HomeBudget.Components.IntegrationTests/HomeBudget.Components.IntegrationTests.csproj
@@ -13,7 +13,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
     <PackageReference Include="NUnit" Version="4.0.1" />
     <PackageReference Include="Moq" Version="4.20.70" />
-    <PackageReference Include="NUnit.Analyzers" Version="3.10.0">
+    <PackageReference Include="NUnit.Analyzers" Version="4.0.1">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>


### PR DESCRIPTION
NuKeeper has generated a major update of `NUnit.Analyzers` to `4.0.1` from `3.10.0`
`NUnit.Analyzers 4.0.1` was published at `2024-02-01T21:21:20Z`, 7 days ago

1 project update:
Updated `HomeBudget.Components.IntegrationTests/HomeBudget.Components.IntegrationTests.csproj` to `NUnit.Analyzers` `4.0.1` from `3.10.0`

[NUnit.Analyzers 4.0.1 on NuGet.org](https://www.nuget.org/packages/NUnit.Analyzers/4.0.1)


This is an automated update. Merge only if it passes tests
**NuKeeper**: https://github.com/NuKeeperDotNet/NuKeeper
