### PR TITLE
Automatic update of Polly to 8.3.0

### DIFF
--- a/HomeBudget.Components.CurrencyRates/HomeBudget.Components.CurrencyRates.csproj
+++ b/HomeBudget.Components.CurrencyRates/HomeBudget.Components.CurrencyRates.csproj
@@ -11,7 +11,7 @@
 		<PackageReference Include="MediatR" Version="12.2.0" />
 		<PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.0" />
 		<PackageReference Include="Microsoft.Extensions.Http" Version="8.0.0" />
-		<PackageReference Include="Polly" Version="8.2.1" />
+		<PackageReference Include="Polly" Version="8.3.0" />
 		<PackageReference Include="Microsoft.Extensions.Http.Polly" Version="8.0.1" />
 		<PackageReference Include="Polly.Extensions.Http" Version="3.0.0" />
 		<PackageReference Include="Refit.Newtonsoft.Json" Version="7.0.0" />


### PR DESCRIPTION
NuKeeper has generated a minor update of `Polly` to `8.3.0` from `8.2.1`
`Polly 8.3.0` was published at `2024-02-05T11:17:26Z`, 7 days ago

1 project update:
Updated `HomeBudget.Components.CurrencyRates/HomeBudget.Components.CurrencyRates.csproj` to `Polly` `8.3.0` from `8.2.1`

[Polly 8.3.0 on NuGet.org](https://www.nuget.org/packages/Polly/8.3.0)


This is an automated update. Merge only if it passes tests
**NuKeeper**: https://github.com/NuKeeperDotNet/NuKeeper
