### PR TITLE
Automatic update of System.IdentityModel.Tokens.Jwt to 7.4.0

### DIFF
--- a/HomeBudget.Rates.Api/HomeBudget.Rates.Api.csproj
+++ b/HomeBudget.Rates.Api/HomeBudget.Rates.Api.csproj
@@ -30,7 +30,7 @@
     <PackageReference Include="StackExchange.Redis" Version="2.7.20" />
     <PackageReference Include="Serilog.Sinks.Elasticsearch" Version="9.0.3" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />
-    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="7.3.1" />
+    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="7.4.0" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
NuKeeper has generated a minor update of `System.IdentityModel.Tokens.Jwt` to `7.4.0` from `7.3.1`
`System.IdentityModel.Tokens.Jwt 7.4.0` was published at `2024-02-26T20:47:56Z`, 7 days ago

1 project update:
Updated `HomeBudget.Rates.Api/HomeBudget.Rates.Api.csproj` to `System.IdentityModel.Tokens.Jwt` `7.4.0` from `7.3.1`

[System.IdentityModel.Tokens.Jwt 7.4.0 on NuGet.org](https://www.nuget.org/packages/System.IdentityModel.Tokens.Jwt/7.4.0)


This is an automated update. Merge only if it passes tests
**NuKeeper**: https://github.com/NuKeeperDotNet/NuKeeper
