### PR TITLE
Automatic update of StackExchange.Redis to 2.7.33

### DIFF
--- a/HomeBudget.Core/HomeBudget.Core.csproj
+++ b/HomeBudget.Core/HomeBudget.Core.csproj
@@ -9,7 +9,7 @@
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.0" />
     <PackageReference Include="Microsoft.Extensions.Options" Version="8.0.2" />
-    <PackageReference Include="StackExchange.Redis" Version="2.7.27" />
+    <PackageReference Include="StackExchange.Redis" Version="2.7.33" />
   </ItemGroup>
 
   <ItemGroup>

--- a/HomeBudget.Rates.Api/HomeBudget.Rates.Api.csproj
+++ b/HomeBudget.Rates.Api/HomeBudget.Rates.Api.csproj
@@ -27,7 +27,7 @@
     <PackageReference Include="Serilog.Extensions.Logging" Version="8.0.0" />
     <PackageReference Include="Serilog.Formatting.Compact" Version="2.0.0" />
     <PackageReference Include="Serilog.Sinks.Debug" Version="2.0.0" />
-    <PackageReference Include="StackExchange.Redis" Version="2.7.27" />
+    <PackageReference Include="StackExchange.Redis" Version="2.7.33" />
     <PackageReference Include="Serilog.Sinks.Elasticsearch" Version="9.0.3" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />
     <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="7.4.0" />


### PR DESCRIPTION
NuKeeper has generated a patch update of `StackExchange.Redis` to `2.7.33` from `2.7.27`
`StackExchange.Redis 2.7.33` was published at `2024-03-11T15:03:55Z`, 7 days ago

2 project updates:
Updated `HomeBudget.Core/HomeBudget.Core.csproj` to `StackExchange.Redis` `2.7.33` from `2.7.27`
Updated `HomeBudget.Rates.Api/HomeBudget.Rates.Api.csproj` to `StackExchange.Redis` `2.7.33` from `2.7.27`

[StackExchange.Redis 2.7.33 on NuGet.org](https://www.nuget.org/packages/StackExchange.Redis/2.7.33)


This is an automated update. Merge only if it passes tests
**NuKeeper**: https://github.com/NuKeeperDotNet/NuKeeper
