### PR TITLE
Automatic update of Microsoft.Extensions.DependencyInjection.Abstractions to 8.0.1

### DIFF
--- a/HomeBudget.Components.CurrencyRates/HomeBudget.Components.CurrencyRates.csproj
+++ b/HomeBudget.Components.CurrencyRates/HomeBudget.Components.CurrencyRates.csproj
@@ -9,7 +9,7 @@
 	<ItemGroup>
 		<PackageReference Include="AutoMapper" Version="13.0.1" />
 		<PackageReference Include="MediatR" Version="12.2.0" />
-		<PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.0" />
+		<PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.1" />
 		<PackageReference Include="Microsoft.Extensions.Http" Version="8.0.0" />
 		<PackageReference Include="Polly" Version="8.3.1" />
 		<PackageReference Include="Microsoft.Extensions.Http.Polly" Version="8.0.2" />

--- a/HomeBudget.Core/HomeBudget.Core.csproj
+++ b/HomeBudget.Core/HomeBudget.Core.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.1" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.0" />
     <PackageReference Include="Microsoft.Extensions.Options" Version="8.0.2" />
     <PackageReference Include="StackExchange.Redis" Version="2.7.27" />


### PR DESCRIPTION
NuKeeper has generated a patch update of `Microsoft.Extensions.DependencyInjection.Abstractions` to `8.0.1` from `8.0.0`
`Microsoft.Extensions.DependencyInjection.Abstractions 8.0.1` was published at `2024-03-12T13:26:29Z`, 7 days ago

2 project updates:
Updated `HomeBudget.Core/HomeBudget.Core.csproj` to `Microsoft.Extensions.DependencyInjection.Abstractions` `8.0.1` from `8.0.0`
Updated `HomeBudget.Components.CurrencyRates/HomeBudget.Components.CurrencyRates.csproj` to `Microsoft.Extensions.DependencyInjection.Abstractions` `8.0.1` from `8.0.0`

[Microsoft.Extensions.DependencyInjection.Abstractions 8.0.1 on NuGet.org](https://www.nuget.org/packages/Microsoft.Extensions.DependencyInjection.Abstractions/8.0.1)


This is an automated update. Merge only if it passes tests
**NuKeeper**: https://github.com/NuKeeperDotNet/NuKeeper
