### PR TITLE
Automatic update of Serilog.Sinks.Elasticsearch to 10.0.0

### DIFF
--- a/HomeBudget.Rates.Api/HomeBudget.Rates.Api.csproj
+++ b/HomeBudget.Rates.Api/HomeBudget.Rates.Api.csproj
@@ -28,7 +28,7 @@
     <PackageReference Include="Serilog.Formatting.Compact" Version="2.0.0" />
     <PackageReference Include="Serilog.Sinks.Debug" Version="2.0.0" />
     <PackageReference Include="StackExchange.Redis" Version="2.7.27" />
-    <PackageReference Include="Serilog.Sinks.Elasticsearch" Version="9.0.3" />
+    <PackageReference Include="Serilog.Sinks.Elasticsearch" Version="10.0.0" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />
     <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="7.4.0" />
   </ItemGroup>


### PR DESCRIPTION
NuKeeper has generated a major update of `Serilog.Sinks.Elasticsearch` to `10.0.0` from `9.0.3`
`Serilog.Sinks.Elasticsearch 10.0.0` was published at `2024-03-12T14:06:27Z`, 7 days ago

1 project update:
Updated `HomeBudget.Rates.Api/HomeBudget.Rates.Api.csproj` to `Serilog.Sinks.Elasticsearch` `10.0.0` from `9.0.3`

[Serilog.Sinks.Elasticsearch 10.0.0 on NuGet.org](https://www.nuget.org/packages/Serilog.Sinks.Elasticsearch/10.0.0)


This is an automated update. Merge only if it passes tests
**NuKeeper**: https://github.com/NuKeeperDotNet/NuKeeper
