### PR TITLE
Automatic update of System.IdentityModel.Tokens.Jwt to 7.4.1

### DIFF
--- a/HomeBudget.Rates.Api/HomeBudget.Rates.Api.csproj
+++ b/HomeBudget.Rates.Api/HomeBudget.Rates.Api.csproj
@@ -30,7 +30,7 @@
     <PackageReference Include="Serilog.Sinks.Elasticsearch" Version="10.0.0" />
     <PackageReference Include="StackExchange.Redis" Version="2.7.33" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />
-    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="7.4.0" />
+    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="7.4.1" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
NuKeeper has generated a patch update of `System.IdentityModel.Tokens.Jwt` to `7.4.1` from `7.4.0`
`System.IdentityModel.Tokens.Jwt 7.4.1` was published at `2024-03-15T19:57:35Z`, 7 days ago

1 project update:
Updated `HomeBudget.Rates.Api/HomeBudget.Rates.Api.csproj` to `System.IdentityModel.Tokens.Jwt` `7.4.1` from `7.4.0`

[System.IdentityModel.Tokens.Jwt 7.4.1 on NuGet.org](https://www.nuget.org/packages/System.IdentityModel.Tokens.Jwt/7.4.1)


This is an automated update. Merge only if it passes tests
**NuKeeper**: https://github.com/NuKeeperDotNet/NuKeeper
