### PR TITLE
Automatic update of Datadog.Trace.Bundle to 2.49.0

### DIFF
--- a/HomeBudget.Rates.Api/HomeBudget.Rates.Api.csproj
+++ b/HomeBudget.Rates.Api/HomeBudget.Rates.Api.csproj
@@ -14,7 +14,7 @@
     <PackageReference Include="AspNetCore.HealthChecks.UI" Version="8.0.0" />
     <PackageReference Include="AspNetCore.HealthChecks.UI.Client" Version="8.0.0" />
     <PackageReference Include="AspNetCore.HealthChecks.UI.InMemory.Storage" Version="8.0.0" />
-    <PackageReference Include="Datadog.Trace.Bundle" Version="2.48.0" />
+    <PackageReference Include="Datadog.Trace.Bundle" Version="2.49.0" />
     <PackageReference Include="FluentValidation.AspNetCore" Version="11.3.0" />
     <PackageReference Include="FluentValidation.DependencyInjectionExtensions" Version="11.9.0" />
     <PackageReference Include="Microsoft.AspNetCore.HeaderPropagation" Version="8.0.3" />


### PR DESCRIPTION
NuKeeper has generated a minor update of `Datadog.Trace.Bundle` to `2.49.0` from `2.48.0`
`Datadog.Trace.Bundle 2.49.0` was published at `2024-03-18T14:54:48Z`, 7 days ago

1 project update:
Updated `HomeBudget.Rates.Api/HomeBudget.Rates.Api.csproj` to `Datadog.Trace.Bundle` `2.49.0` from `2.48.0`

[Datadog.Trace.Bundle 2.49.0 on NuGet.org](https://www.nuget.org/packages/Datadog.Trace.Bundle/2.49.0)


This is an automated update. Merge only if it passes tests
**NuKeeper**: https://github.com/NuKeeperDotNet/NuKeeper
