### PR TITLE
Automatic update of Testcontainers to 3.8.0

### DIFF
--- a/HomeBudget.Components.IntegrationTests/HomeBudget.Components.IntegrationTests.csproj
+++ b/HomeBudget.Components.IntegrationTests/HomeBudget.Components.IntegrationTests.csproj
@@ -24,7 +24,7 @@
     </PackageReference>
 
     <PackageReference Include="RestSharp" Version="110.2.0" />
-    <PackageReference Include="Testcontainers" Version="3.7.0" />
+    <PackageReference Include="Testcontainers" Version="3.8.0" />
     <PackageReference Include="Testcontainers.MsSql" Version="3.7.0" />
     <PackageReference Include="Testcontainers.Redis" Version="3.7.0" />
   </ItemGroup>


### PR DESCRIPTION
NuKeeper has generated a minor update of `Testcontainers` to `3.8.0` from `3.7.0`
`Testcontainers 3.8.0` was published at `2024-03-19T15:11:08Z`, 7 days ago

1 project update:
Updated `HomeBudget.Components.IntegrationTests/HomeBudget.Components.IntegrationTests.csproj` to `Testcontainers` `3.8.0` from `3.7.0`

[Testcontainers 3.8.0 on NuGet.org](https://www.nuget.org/packages/Testcontainers/3.8.0)


This is an automated update. Merge only if it passes tests
**NuKeeper**: https://github.com/NuKeeperDotNet/NuKeeper
