### PR TITLE
Automatic update of AspNetCore.HealthChecks.UI.InMemory.Storage to 8.0.1

### DIFF
--- a/HomeBudget.Rates.Api/HomeBudget.Rates.Api.csproj
+++ b/HomeBudget.Rates.Api/HomeBudget.Rates.Api.csproj
@@ -13,7 +13,7 @@
     <PackageReference Include="AspNetCore.HealthChecks.SqlServer" Version="8.0.1" />
     <PackageReference Include="AspNetCore.HealthChecks.UI" Version="8.0.0" />
     <PackageReference Include="AspNetCore.HealthChecks.UI.Client" Version="8.0.0" />
-    <PackageReference Include="AspNetCore.HealthChecks.UI.InMemory.Storage" Version="8.0.0" />
+    <PackageReference Include="AspNetCore.HealthChecks.UI.InMemory.Storage" Version="8.0.1" />
     <PackageReference Include="Datadog.Trace.Bundle" Version="2.49.0" />
     <PackageReference Include="FluentValidation.AspNetCore" Version="11.3.0" />
     <PackageReference Include="FluentValidation.DependencyInjectionExtensions" Version="11.9.0" />


### PR DESCRIPTION
NuKeeper has generated a patch update of `AspNetCore.HealthChecks.UI.InMemory.Storage` to `8.0.1` from `8.0.0`
`AspNetCore.HealthChecks.UI.InMemory.Storage 8.0.1` was published at `2024-04-02T14:45:44Z`, 7 days ago

1 project update:
Updated `HomeBudget.Rates.Api/HomeBudget.Rates.Api.csproj` to `AspNetCore.HealthChecks.UI.InMemory.Storage` `8.0.1` from `8.0.0`

[AspNetCore.HealthChecks.UI.InMemory.Storage 8.0.1 on NuGet.org](https://www.nuget.org/packages/AspNetCore.HealthChecks.UI.InMemory.Storage/8.0.1)


This is an automated update. Merge only if it passes tests
**NuKeeper**: https://github.com/NuKeeperDotNet/NuKeeper
