### PR TITLE
Automatic update of SonarAnalyzer.CSharp to 9.23.1.88495

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -5,6 +5,6 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.118" PrivateAssets="all" Condition="$(MSBuildProjectExtension) == '.csproj'" />
-    <PackageReference Include="SonarAnalyzer.CSharp" Version="9.23.0.88079" PrivateAssets="all" Condition="$(MSBuildProjectExtension) == '.csproj'" />
+    <PackageReference Include="SonarAnalyzer.CSharp" Version="9.23.1.88495" PrivateAssets="all" Condition="$(MSBuildProjectExtension) == '.csproj'" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
NuKeeper has generated a patch update of `SonarAnalyzer.CSharp` to `9.23.1.88495` from `9.23.0.88079`
`SonarAnalyzer.CSharp 9.23.1.88495` was published at `2024-04-02T14:29:05Z`, 7 days ago

1 project update:
Updated `Directory.Build.props` to `SonarAnalyzer.CSharp` `9.23.1.88495` from `9.23.0.88079`

[SonarAnalyzer.CSharp 9.23.1.88495 on NuGet.org](https://www.nuget.org/packages/SonarAnalyzer.CSharp/9.23.1.88495)


This is an automated update. Merge only if it passes tests
**NuKeeper**: https://github.com/NuKeeperDotNet/NuKeeper
