### PR TITLE
Automatic update of Microsoft.Extensions.Http.Polly to 8.0.4

### DIFF
--- a/HomeBudget.Components.CurrencyRates/HomeBudget.Components.CurrencyRates.csproj
+++ b/HomeBudget.Components.CurrencyRates/HomeBudget.Components.CurrencyRates.csproj
@@ -12,7 +12,7 @@
 		<PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.1" />
 		<PackageReference Include="Microsoft.Extensions.Http" Version="8.0.0" />
 		<PackageReference Include="Polly" Version="8.3.1" />
-		<PackageReference Include="Microsoft.Extensions.Http.Polly" Version="8.0.3" />
+		<PackageReference Include="Microsoft.Extensions.Http.Polly" Version="8.0.4" />
 		<PackageReference Include="Polly.Extensions.Http" Version="3.0.0" />
 		<PackageReference Include="Refit.Newtonsoft.Json" Version="7.0.0" />
 		<PackageReference Include="Refit.HttpClientFactory" Version="7.0.0" />


### PR DESCRIPTION
NuKeeper has generated a patch update of `Microsoft.Extensions.Http.Polly` to `8.0.4` from `8.0.3`
`Microsoft.Extensions.Http.Polly 8.0.4` was published at `2024-04-09T17:04:22Z`, 7 days ago

1 project update:
Updated `HomeBudget.Components.CurrencyRates/HomeBudget.Components.CurrencyRates.csproj` to `Microsoft.Extensions.Http.Polly` `8.0.4` from `8.0.3`

[Microsoft.Extensions.Http.Polly 8.0.4 on NuGet.org](https://www.nuget.org/packages/Microsoft.Extensions.Http.Polly/8.0.4)


This is an automated update. Merge only if it passes tests
**NuKeeper**: https://github.com/NuKeeperDotNet/NuKeeper
