### PR TITLE
Automatic update of SonarAnalyzer.CSharp to 9.25.0.90414

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -5,6 +5,6 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.118" PrivateAssets="all" Condition="$(MSBuildProjectExtension) == '.csproj'" />
-    <PackageReference Include="SonarAnalyzer.CSharp" Version="9.24.0.89429" PrivateAssets="all" Condition="$(MSBuildProjectExtension) == '.csproj'" />
+    <PackageReference Include="SonarAnalyzer.CSharp" Version="9.25.0.90414" PrivateAssets="all" Condition="$(MSBuildProjectExtension) == '.csproj'" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
NuKeeper has generated a minor update of `SonarAnalyzer.CSharp` to `9.25.0.90414` from `9.24.0.89429`
`SonarAnalyzer.CSharp 9.25.0.90414` was published at `2024-05-06T14:56:08Z`, 7 days ago

1 project update:
Updated `Directory.Build.props` to `SonarAnalyzer.CSharp` `9.25.0.90414` from `9.24.0.89429`

[SonarAnalyzer.CSharp 9.25.0.90414 on NuGet.org](https://www.nuget.org/packages/SonarAnalyzer.CSharp/9.25.0.90414)


This is an automated update. Merge only if it passes tests
**NuKeeper**: https://github.com/NuKeeperDotNet/NuKeeper
