### PR TITLE
Automatic update of Microsoft.Extensions.Http.Resilience to 8.5.0

### DIFF
--- a/HomeBudget.Components.CurrencyRates/HomeBudget.Components.CurrencyRates.csproj
+++ b/HomeBudget.Components.CurrencyRates/HomeBudget.Components.CurrencyRates.csproj
@@ -11,7 +11,7 @@
 		<PackageReference Include="MediatR" Version="12.2.0" />
 		<PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.1" />
 		<PackageReference Include="Microsoft.Extensions.Http" Version="8.0.0" />
-		<PackageReference Include="Microsoft.Extensions.Http.Resilience" Version="8.4.0" />
+		<PackageReference Include="Microsoft.Extensions.Http.Resilience" Version="8.5.0" />
 		<PackageReference Include="Polly" Version="8.4.0" />
 		<PackageReference Include="Microsoft.Extensions.Http.Polly" Version="8.0.4" />
 		<PackageReference Include="Refit.Newtonsoft.Json" Version="7.0.0" />


### PR DESCRIPTION
NuKeeper has generated a minor update of `Microsoft.Extensions.Http.Resilience` to `8.5.0` from `8.4.0`
`Microsoft.Extensions.Http.Resilience 8.5.0` was published at `2024-05-14T16:53:35Z`, 7 days ago

1 project update:
Updated `HomeBudget.Components.CurrencyRates/HomeBudget.Components.CurrencyRates.csproj` to `Microsoft.Extensions.Http.Resilience` `8.5.0` from `8.4.0`

[Microsoft.Extensions.Http.Resilience 8.5.0 on NuGet.org](https://www.nuget.org/packages/Microsoft.Extensions.Http.Resilience/8.5.0)


This is an automated update. Merge only if it passes tests
**NuKeeper**: https://github.com/NuKeeperDotNet/NuKeeper
