### PR TITLE
Automatic update of Microsoft.AspNetCore.HeaderPropagation to 8.0.5

### DIFF
--- a/HomeBudget.Rates.Api/HomeBudget.Rates.Api.csproj
+++ b/HomeBudget.Rates.Api/HomeBudget.Rates.Api.csproj
@@ -17,7 +17,7 @@
     <PackageReference Include="Datadog.Trace.Bundle" Version="2.51.0" />
     <PackageReference Include="FluentValidation.AspNetCore" Version="11.3.0" />
     <PackageReference Include="FluentValidation.DependencyInjectionExtensions" Version="11.9.1" />
-    <PackageReference Include="Microsoft.AspNetCore.HeaderPropagation" Version="8.0.4" />
+    <PackageReference Include="Microsoft.AspNetCore.HeaderPropagation" Version="8.0.5" />
     <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.20.1" />
     <PackageReference Include="Serilog.AspNetCore" Version="8.0.1" />
     <PackageReference Include="Serilog.Enrichers.Environment" Version="2.3.0" />


### PR DESCRIPTION
NuKeeper has generated a patch update of `Microsoft.AspNetCore.HeaderPropagation` to `8.0.5` from `8.0.4`
`Microsoft.AspNetCore.HeaderPropagation 8.0.5` was published at `2024-05-14T14:43:57Z`, 7 days ago

1 project update:
Updated `HomeBudget.Rates.Api/HomeBudget.Rates.Api.csproj` to `Microsoft.AspNetCore.HeaderPropagation` `8.0.5` from `8.0.4`

[Microsoft.AspNetCore.HeaderPropagation 8.0.5 on NuGet.org](https://www.nuget.org/packages/Microsoft.AspNetCore.HeaderPropagation/8.0.5)


This is an automated update. Merge only if it passes tests
**NuKeeper**: https://github.com/NuKeeperDotNet/NuKeeper
