### PR TITLE
Automatic update of OpenTelemetry.Exporter.Prometheus.AspNetCore to 1.9.0-alpha.1

### DIFF
--- a/HomeBudget.Rates.Api/HomeBudget.Rates.Api.csproj
+++ b/HomeBudget.Rates.Api/HomeBudget.Rates.Api.csproj
@@ -24,7 +24,7 @@
     <PackageReference Include="OpenTelemetry" Version="1.8.1" />
     <PackageReference Include="OpenTelemetry.Api" Version="1.8.1" />
     <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.8.1" />
-    <PackageReference Include="OpenTelemetry.Exporter.Prometheus.AspNetCore" Version="1.7.0-rc.1" />
+    <PackageReference Include="OpenTelemetry.Exporter.Prometheus.AspNetCore" Version="1.9.0-alpha.1" />
     <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.8.1" />
     <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.8.1" />
     <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.8.1" />


### PR DESCRIPTION
NuKeeper has generated a minor update of `OpenTelemetry.Exporter.Prometheus.AspNetCore` to `1.9.0-alpha.1` from `1.7.0-rc.1`
`OpenTelemetry.Exporter.Prometheus.AspNetCore 1.9.0-alpha.1` was published at `2024-05-20T21:32:26Z`, 7 days ago

1 project update:
Updated `HomeBudget.Rates.Api/HomeBudget.Rates.Api.csproj` to `OpenTelemetry.Exporter.Prometheus.AspNetCore` `1.9.0-alpha.1` from `1.7.0-rc.1`

[OpenTelemetry.Exporter.Prometheus.AspNetCore 1.9.0-alpha.1 on NuGet.org](https://www.nuget.org/packages/OpenTelemetry.Exporter.Prometheus.AspNetCore/1.9.0-alpha.1)


This is an automated update. Merge only if it passes tests
**NuKeeper**: https://github.com/NuKeeperDotNet/NuKeeper
