### PR TITLE
Automatic update of Microsoft.NET.Test.Sdk to 17.10.0

### DIFF
--- a/HomeBudget.Components.CurrencyRates.Tests/HomeBudget.Components.CurrencyRates.Tests.csproj
+++ b/HomeBudget.Components.CurrencyRates.Tests/HomeBudget.Components.CurrencyRates.Tests.csproj
@@ -9,7 +9,7 @@
   <ItemGroup>
     <PackageReference Include="AutoMapper" Version="13.0.1" />
     <PackageReference Include="FluentAssertions" Version="6.12.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
     <PackageReference Include="NUnit" Version="4.1.0" />
     <PackageReference Include="Moq" Version="4.20.70" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />

--- a/HomeBudget.Components.IntegrationTests/HomeBudget.Components.IntegrationTests.csproj
+++ b/HomeBudget.Components.IntegrationTests/HomeBudget.Components.IntegrationTests.csproj
@@ -10,7 +10,7 @@
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.5" />
     <PackageReference Include="FluentAssertions" Version="6.12.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.1" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
     <PackageReference Include="NUnit" Version="4.1.0" />
     <PackageReference Include="Moq" Version="4.20.70" />
     <PackageReference Include="NUnit.Analyzers" Version="4.2.0">

--- a/HomeBudget.Rates.Api.Tests/HomeBudget.Rates.Api.Tests.csproj
+++ b/HomeBudget.Rates.Api.Tests/HomeBudget.Rates.Api.Tests.csproj
@@ -15,7 +15,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
     <PackageReference Include="NUnit" Version="4.1.0" />
     <PackageReference Include="NUnit.Analyzers" Version="4.2.0">
       <PrivateAssets>all</PrivateAssets>


### PR DESCRIPTION
NuKeeper has generated a minor update of `Microsoft.NET.Test.Sdk` to `17.10.0` from `17.9.0`
`Microsoft.NET.Test.Sdk 17.10.0` was published at `2024-05-22T14:49:27Z`, 7 days ago

3 project updates:
Updated `HomeBudget.Rates.Api.Tests/HomeBudget.Rates.Api.Tests.csproj` to `Microsoft.NET.Test.Sdk` `17.10.0` from `17.9.0`
Updated `HomeBudget.Components.IntegrationTests/HomeBudget.Components.IntegrationTests.csproj` to `Microsoft.NET.Test.Sdk` `17.10.0` from `17.9.0`
Updated `HomeBudget.Components.CurrencyRates.Tests/HomeBudget.Components.CurrencyRates.Tests.csproj` to `Microsoft.NET.Test.Sdk` `17.10.0` from `17.9.0`

[Microsoft.NET.Test.Sdk 17.10.0 on NuGet.org](https://www.nuget.org/packages/Microsoft.NET.Test.Sdk/17.10.0)


This is an automated update. Merge only if it passes tests
**NuKeeper**: https://github.com/NuKeeperDotNet/NuKeeper
