### PR TITLE
Automatic update of Azure.Identity to 1.11.4

### DIFF
--- a/HomeBudget.Rates.Api/HomeBudget.Rates.Api.csproj
+++ b/HomeBudget.Rates.Api/HomeBudget.Rates.Api.csproj
@@ -15,7 +15,7 @@
     <PackageReference Include="AspNetCore.HealthChecks.UI" Version="8.0.1" />
     <PackageReference Include="AspNetCore.HealthChecks.UI.Client" Version="8.0.1" />
     <PackageReference Include="AspNetCore.HealthChecks.UI.InMemory.Storage" Version="8.0.1" />
-    <PackageReference Include="Azure.Identity" Version="1.11.3" />
+    <PackageReference Include="Azure.Identity" Version="1.11.4" />
     <PackageReference Include="Datadog.Trace.Bundle" Version="2.52.0" />
     <PackageReference Include="FluentValidation.AspNetCore" Version="11.3.0" />
     <PackageReference Include="FluentValidation.DependencyInjectionExtensions" Version="11.9.1" />


### PR DESCRIPTION
NuKeeper has generated a patch update of `Azure.Identity` to `1.11.4` from `1.11.3`
`Azure.Identity 1.11.4` was published at `2024-06-10T17:12:28Z`, 7 days ago

1 project update:
Updated `HomeBudget.Rates.Api/HomeBudget.Rates.Api.csproj` to `Azure.Identity` `1.11.4` from `1.11.3`

[Azure.Identity 1.11.4 on NuGet.org](https://www.nuget.org/packages/Azure.Identity/1.11.4)


This is an automated update. Merge only if it passes tests
**NuKeeper**: https://github.com/NuKeeperDotNet/NuKeeper
