### PR TITLE
Automatic update of FluentValidation.DependencyInjectionExtensions to 11.9.2

### DIFF
--- a/HomeBudget.Rates.Api/HomeBudget.Rates.Api.csproj
+++ b/HomeBudget.Rates.Api/HomeBudget.Rates.Api.csproj
@@ -18,7 +18,7 @@
     <PackageReference Include="Azure.Identity" Version="1.11.3" />
     <PackageReference Include="Datadog.Trace.Bundle" Version="2.52.0" />
     <PackageReference Include="FluentValidation.AspNetCore" Version="11.3.0" />
-    <PackageReference Include="FluentValidation.DependencyInjectionExtensions" Version="11.9.1" />
+    <PackageReference Include="FluentValidation.DependencyInjectionExtensions" Version="11.9.2" />
     <PackageReference Include="Microsoft.AspNetCore.HeaderPropagation" Version="8.0.6" />
     <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.20.1" />
     <PackageReference Include="OpenTelemetry" Version="1.8.1" />


### PR DESCRIPTION
NuKeeper has generated a patch update of `FluentValidation.DependencyInjectionExtensions` to `11.9.2` from `11.9.1`
`FluentValidation.DependencyInjectionExtensions 11.9.2` was published at `2024-06-10T12:21:42Z`, 7 days ago

1 project update:
Updated `HomeBudget.Rates.Api/HomeBudget.Rates.Api.csproj` to `FluentValidation.DependencyInjectionExtensions` `11.9.2` from `11.9.1`

[FluentValidation.DependencyInjectionExtensions 11.9.2 on NuGet.org](https://www.nuget.org/packages/FluentValidation.DependencyInjectionExtensions/11.9.2)


This is an automated update. Merge only if it passes tests
**NuKeeper**: https://github.com/NuKeeperDotNet/NuKeeper
