### PR TITLE
Automatic update of Serilog.Sinks.Debug to 3.0.0

### DIFF
--- a/HomeBudget.Rates.Api/HomeBudget.Rates.Api.csproj
+++ b/HomeBudget.Rates.Api/HomeBudget.Rates.Api.csproj
@@ -39,7 +39,7 @@
     <PackageReference Include="Serilog.Exceptions" Version="8.4.0" />
     <PackageReference Include="Serilog.Extensions.Logging" Version="8.0.0" />
     <PackageReference Include="Serilog.Formatting.Compact" Version="3.0.0" />
-    <PackageReference Include="Serilog.Sinks.Debug" Version="2.0.0" />
+    <PackageReference Include="Serilog.Sinks.Debug" Version="3.0.0" />
     <PackageReference Include="Serilog.Sinks.Elasticsearch" Version="10.0.0" />
     <PackageReference Include="StackExchange.Redis" Version="2.7.33" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.6.2" />


### PR DESCRIPTION
NuKeeper has generated a major update of `Serilog.Sinks.Debug` to `3.0.0` from `2.0.0`
`Serilog.Sinks.Debug 3.0.0` was published at `2024-06-14T08:12:26Z`, 7 days ago

1 project update:
Updated `HomeBudget.Rates.Api/HomeBudget.Rates.Api.csproj` to `Serilog.Sinks.Debug` `3.0.0` from `2.0.0`

[Serilog.Sinks.Debug 3.0.0 on NuGet.org](https://www.nuget.org/packages/Serilog.Sinks.Debug/3.0.0)


This is an automated update. Merge only if it passes tests
**NuKeeper**: https://github.com/NuKeeperDotNet/NuKeeper
