### PR TITLE
Automatic update of OpenTelemetry.Extensions.Hosting to 1.9.0

### DIFF
--- a/HomeBudget.Rates.Api/HomeBudget.Rates.Api.csproj
+++ b/HomeBudget.Rates.Api/HomeBudget.Rates.Api.csproj
@@ -25,7 +25,7 @@
     <PackageReference Include="OpenTelemetry.Api" Version="1.8.1" />
     <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.8.1" />
     <PackageReference Include="OpenTelemetry.Exporter.Prometheus.AspNetCore" Version="1.7.0-rc.1" />
-    <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.8.1" />
+    <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.9.0" />
     <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.8.1" />
     <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.8.1" />
     <PackageReference Include="OpenTelemetry.Instrumentation.Runtime" Version="1.8.1" />


### PR DESCRIPTION
NuKeeper has generated a minor update of `OpenTelemetry.Extensions.Hosting` to `1.9.0` from `1.8.1`
`OpenTelemetry.Extensions.Hosting 1.9.0` was published at `2024-06-14T20:03:53Z`, 7 days ago

1 project update:
Updated `HomeBudget.Rates.Api/HomeBudget.Rates.Api.csproj` to `OpenTelemetry.Extensions.Hosting` `1.9.0` from `1.8.1`

[OpenTelemetry.Extensions.Hosting 1.9.0 on NuGet.org](https://www.nuget.org/packages/OpenTelemetry.Extensions.Hosting/1.9.0)


This is an automated update. Merge only if it passes tests
**NuKeeper**: https://github.com/NuKeeperDotNet/NuKeeper
