### PR TITLE
Automatic update of Testcontainers.Redis to 3.9.0

### DIFF
--- a/HomeBudget.Components.IntegrationTests/HomeBudget.Components.IntegrationTests.csproj
+++ b/HomeBudget.Components.IntegrationTests/HomeBudget.Components.IntegrationTests.csproj
@@ -24,7 +24,7 @@
     </PackageReference>
 
     <PackageReference Include="RestSharp" Version="111.2.0" />
-    <PackageReference Include="Testcontainers.Redis" Version="3.8.0" />
+    <PackageReference Include="Testcontainers.Redis" Version="3.9.0" />
     <PackageReference Include="Testcontainers.MsSql" Version="3.8.0" />
     <PackageReference Include="Testcontainers" Version="3.8.0" />
   </ItemGroup>


### PR DESCRIPTION
NuKeeper has generated a minor update of `Testcontainers.Redis` to `3.9.0` from `3.8.0`
`Testcontainers.Redis 3.9.0` was published at `2024-06-16T15:33:59Z`, 7 days ago

1 project update:
Updated `HomeBudget.Components.IntegrationTests/HomeBudget.Components.IntegrationTests.csproj` to `Testcontainers.Redis` `3.9.0` from `3.8.0`

[Testcontainers.Redis 3.9.0 on NuGet.org](https://www.nuget.org/packages/Testcontainers.Redis/3.9.0)


This is an automated update. Merge only if it passes tests
**NuKeeper**: https://github.com/NuKeeperDotNet/NuKeeper
