### PR TITLE
Automatic update of OpenTelemetry.Instrumentation.AspNetCore to 1.9.0

### DIFF
--- a/HomeBudget.Rates.Api/HomeBudget.Rates.Api.csproj
+++ b/HomeBudget.Rates.Api/HomeBudget.Rates.Api.csproj
@@ -26,7 +26,7 @@
     <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.9.0" />
     <PackageReference Include="OpenTelemetry.Exporter.Prometheus.AspNetCore" Version="1.7.0-rc.1" />
     <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.9.0" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.8.1" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.9.0" />
     <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.8.1" />
     <PackageReference Include="OpenTelemetry.Instrumentation.Runtime" Version="1.8.1" />
     <PackageReference Include="prometheus-net" Version="8.2.1" />


### PR DESCRIPTION
NuKeeper has generated a minor update of `OpenTelemetry.Instrumentation.AspNetCore` to `1.9.0` from `1.8.1`
`OpenTelemetry.Instrumentation.AspNetCore 1.9.0` was published at `2024-06-17T21:25:49Z`, 7 days ago

1 project update:
Updated `HomeBudget.Rates.Api/HomeBudget.Rates.Api.csproj` to `OpenTelemetry.Instrumentation.AspNetCore` `1.9.0` from `1.8.1`

[OpenTelemetry.Instrumentation.AspNetCore 1.9.0 on NuGet.org](https://www.nuget.org/packages/OpenTelemetry.Instrumentation.AspNetCore/1.9.0)


This is an automated update. Merge only if it passes tests
**NuKeeper**: https://github.com/NuKeeperDotNet/NuKeeper
