### PR TITLE
Automatic update of OpenTelemetry.Instrumentation.Runtime to 1.9.0

### DIFF
--- a/HomeBudget.Rates.Api/HomeBudget.Rates.Api.csproj
+++ b/HomeBudget.Rates.Api/HomeBudget.Rates.Api.csproj
@@ -28,7 +28,7 @@
     <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.9.0" />
     <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.8.1" />
     <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.8.1" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.Runtime" Version="1.8.1" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.Runtime" Version="1.9.0" />
     <PackageReference Include="prometheus-net" Version="8.2.1" />
     <PackageReference Include="prometheus-net.AspNetCore" Version="8.2.1" />
     <PackageReference Include="prometheus-net.AspNetCore.HealthChecks" Version="8.2.1" />


### PR DESCRIPTION
NuKeeper has generated a minor update of `OpenTelemetry.Instrumentation.Runtime` to `1.9.0` from `1.8.1`
`OpenTelemetry.Instrumentation.Runtime 1.9.0` was published at `2024-06-18T05:34:52Z`, 7 days ago

1 project update:
Updated `HomeBudget.Rates.Api/HomeBudget.Rates.Api.csproj` to `OpenTelemetry.Instrumentation.Runtime` `1.9.0` from `1.8.1`

[OpenTelemetry.Instrumentation.Runtime 1.9.0 on NuGet.org](https://www.nuget.org/packages/OpenTelemetry.Instrumentation.Runtime/1.9.0)


This is an automated update. Merge only if it passes tests
**NuKeeper**: https://github.com/NuKeeperDotNet/NuKeeper
