### PR TITLE
Automatic update of Datadog.Trace.Bundle to 2.53.2

### DIFF
--- a/HomeBudget.Rates.Api/HomeBudget.Rates.Api.csproj
+++ b/HomeBudget.Rates.Api/HomeBudget.Rates.Api.csproj
@@ -16,7 +16,7 @@
     <PackageReference Include="AspNetCore.HealthChecks.UI.Client" Version="8.0.1" />
     <PackageReference Include="AspNetCore.HealthChecks.UI.InMemory.Storage" Version="8.0.1" />
     <PackageReference Include="Azure.Identity" Version="1.11.4" />
-    <PackageReference Include="Datadog.Trace.Bundle" Version="2.52.0" />
+    <PackageReference Include="Datadog.Trace.Bundle" Version="2.53.2" />
     <PackageReference Include="FluentValidation.AspNetCore" Version="11.3.0" />
     <PackageReference Include="FluentValidation.DependencyInjectionExtensions" Version="11.9.2" />
     <PackageReference Include="Microsoft.AspNetCore.HeaderPropagation" Version="8.0.6" />


### PR DESCRIPTION
NuKeeper has generated a minor update of `Datadog.Trace.Bundle` to `2.53.2` from `2.52.0`
`Datadog.Trace.Bundle 2.53.2` was published at `2024-06-19T12:02:38Z`, 7 days ago

1 project update:
Updated `HomeBudget.Rates.Api/HomeBudget.Rates.Api.csproj` to `Datadog.Trace.Bundle` `2.53.2` from `2.52.0`

[Datadog.Trace.Bundle 2.53.2 on NuGet.org](https://www.nuget.org/packages/Datadog.Trace.Bundle/2.53.2)


This is an automated update. Merge only if it passes tests
**NuKeeper**: https://github.com/NuKeeperDotNet/NuKeeper
