### PR TITLE
Automatic update of Serilog.Enrichers.Environment to 3.0.1

### DIFF
--- a/HomeBudget.Rates.Api/HomeBudget.Rates.Api.csproj
+++ b/HomeBudget.Rates.Api/HomeBudget.Rates.Api.csproj
@@ -33,7 +33,7 @@
     <PackageReference Include="prometheus-net.AspNetCore" Version="8.2.1" />
     <PackageReference Include="prometheus-net.AspNetCore.HealthChecks" Version="8.2.1" />
     <PackageReference Include="Serilog.AspNetCore" Version="8.0.1" />
-    <PackageReference Include="Serilog.Enrichers.Environment" Version="3.0.0" />
+    <PackageReference Include="Serilog.Enrichers.Environment" Version="3.0.1" />
     <PackageReference Include="Serilog.Enrichers.Span" Version="3.1.0" />
     <PackageReference Include="Serilog.Enrichers.Thread" Version="4.0.0" />
     <PackageReference Include="Serilog.Exceptions" Version="8.4.0" />


### PR DESCRIPTION
NuKeeper has generated a patch update of `Serilog.Enrichers.Environment` to `3.0.1` from `3.0.0`
`Serilog.Enrichers.Environment 3.0.1` was published at `2024-06-20T05:42:09Z`, 7 days ago

1 project update:
Updated `HomeBudget.Rates.Api/HomeBudget.Rates.Api.csproj` to `Serilog.Enrichers.Environment` `3.0.1` from `3.0.0`

[Serilog.Enrichers.Environment 3.0.1 on NuGet.org](https://www.nuget.org/packages/Serilog.Enrichers.Environment/3.0.1)


This is an automated update. Merge only if it passes tests
**NuKeeper**: https://github.com/NuKeeperDotNet/NuKeeper
