### PR TITLE
Automatic update of RestSharp to 111.4.0

### DIFF
--- a/HomeBudget.Components.IntegrationTests/HomeBudget.Components.IntegrationTests.csproj
+++ b/HomeBudget.Components.IntegrationTests/HomeBudget.Components.IntegrationTests.csproj
@@ -22,7 +22,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="RestSharp" Version="111.3.0" />
+    <PackageReference Include="RestSharp" Version="111.4.0" />
     <PackageReference Include="Testcontainers.Redis" Version="3.9.0" />
     <PackageReference Include="Testcontainers.MsSql" Version="3.9.0" />
     <PackageReference Include="Testcontainers" Version="3.9.0" />


### PR DESCRIPTION
NuKeeper has generated a minor update of `RestSharp` to `111.4.0` from `111.3.0`
`RestSharp 111.4.0` was published at `2024-07-11T17:39:09Z`, 7 days ago

1 project update:
Updated `HomeBudget.Components.IntegrationTests/HomeBudget.Components.IntegrationTests.csproj` to `RestSharp` `111.4.0` from `111.3.0`

[RestSharp 111.4.0 on NuGet.org](https://www.nuget.org/packages/RestSharp/111.4.0)


This is an automated update. Merge only if it passes tests
**NuKeeper**: https://github.com/NuKeeperDotNet/NuKeeper
