### PR TITLE
Automatic update of MediatR to 12.4.0

### DIFF
--- a/HomeBudget.Components.CurrencyRates/HomeBudget.Components.CurrencyRates.csproj
+++ b/HomeBudget.Components.CurrencyRates/HomeBudget.Components.CurrencyRates.csproj
@@ -8,7 +8,7 @@
 
 	<ItemGroup>
 		<PackageReference Include="AutoMapper" Version="13.0.1" />
-		<PackageReference Include="MediatR" Version="12.3.0" />
+		<PackageReference Include="MediatR" Version="12.4.0" />
 		<PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.1" />
 		<PackageReference Include="Microsoft.Extensions.Http" Version="8.0.0" />
 		<PackageReference Include="Microsoft.Extensions.Http.Resilience" Version="8.7.0" />

--- a/HomeBudget.Components.Exchange/HomeBudget.Components.Exchange.csproj
+++ b/HomeBudget.Components.Exchange/HomeBudget.Components.Exchange.csproj
@@ -9,7 +9,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="MediatR" Version="12.3.0" />
+    <PackageReference Include="MediatR" Version="12.4.0" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
NuKeeper has generated a minor update of `MediatR` to `12.4.0` from `12.3.0`
`MediatR 12.4.0` was published at `2024-07-23T19:25:32Z`, 7 days ago

2 project updates:
Updated `HomeBudget.Components.CurrencyRates/HomeBudget.Components.CurrencyRates.csproj` to `MediatR` `12.4.0` from `12.3.0`
Updated `HomeBudget.Components.Exchange/HomeBudget.Components.Exchange.csproj` to `MediatR` `12.4.0` from `12.3.0`

[MediatR 12.4.0 on NuGet.org](https://www.nuget.org/packages/MediatR/12.4.0)


This is an automated update. Merge only if it passes tests
**NuKeeper**: https://github.com/NuKeeperDotNet/NuKeeper
