### PR TITLE
Automatic update of Serilog.AspNetCore to 8.0.2

### DIFF
--- a/HomeBudget.Rates.Api/HomeBudget.Rates.Api.csproj
+++ b/HomeBudget.Rates.Api/HomeBudget.Rates.Api.csproj
@@ -35,7 +35,7 @@
     <PackageReference Include="prometheus-net" Version="8.2.1" />
     <PackageReference Include="prometheus-net.AspNetCore" Version="8.2.1" />
     <PackageReference Include="prometheus-net.AspNetCore.HealthChecks" Version="8.2.1" />
-    <PackageReference Include="Serilog.AspNetCore" Version="8.0.1" />
+    <PackageReference Include="Serilog.AspNetCore" Version="8.0.2" />
     <PackageReference Include="Serilog.Enrichers.Environment" Version="3.0.1" />
     <PackageReference Include="Serilog.Enrichers.Span" Version="3.1.0" />
     <PackageReference Include="Serilog.Enrichers.Thread" Version="4.0.0" />


### PR DESCRIPTION
NuKeeper has generated a patch update of `Serilog.AspNetCore` to `8.0.2` from `8.0.1`
`Serilog.AspNetCore 8.0.2` was published at `2024-07-31T22:55:15Z`, 7 days ago

1 project update:
Updated `HomeBudget.Rates.Api/HomeBudget.Rates.Api.csproj` to `Serilog.AspNetCore` `8.0.2` from `8.0.1`

[Serilog.AspNetCore 8.0.2 on NuGet.org](https://www.nuget.org/packages/Serilog.AspNetCore/8.0.2)


This is an automated update. Merge only if it passes tests
**NuKeeper**: https://github.com/NuKeeperDotNet/NuKeeper
