### PR TITLE
Automatic update of Microsoft.AspNetCore.HeaderPropagation to 8.0.8

### DIFF
--- a/HomeBudget.Rates.Api/HomeBudget.Rates.Api.csproj
+++ b/HomeBudget.Rates.Api/HomeBudget.Rates.Api.csproj
@@ -22,7 +22,7 @@
     <PackageReference Include="FluentValidation.AspNetCore" Version="11.3.0" />
     <PackageReference Include="FluentValidation.DependencyInjectionExtensions" Version="11.9.2" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.7" />
-    <PackageReference Include="Microsoft.AspNetCore.HeaderPropagation" Version="8.0.7" />
+    <PackageReference Include="Microsoft.AspNetCore.HeaderPropagation" Version="8.0.8" />
     <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.21.0" />
     <PackageReference Include="OpenTelemetry" Version="1.9.0" />
     <PackageReference Include="OpenTelemetry.Api" Version="1.9.0" />


### PR DESCRIPTION
NuKeeper has generated a patch update of `Microsoft.AspNetCore.HeaderPropagation` to `8.0.8` from `8.0.7`
`Microsoft.AspNetCore.HeaderPropagation 8.0.8` was published at `2024-08-13T12:57:05Z`, 7 days ago

1 project update:
Updated `HomeBudget.Rates.Api/HomeBudget.Rates.Api.csproj` to `Microsoft.AspNetCore.HeaderPropagation` `8.0.8` from `8.0.7`

[Microsoft.AspNetCore.HeaderPropagation 8.0.8 on NuGet.org](https://www.nuget.org/packages/Microsoft.AspNetCore.HeaderPropagation/8.0.8)


This is an automated update. Merge only if it passes tests
**NuKeeper**: https://github.com/NuKeeperDotNet/NuKeeper
