### PR TITLE
Automatic update of Microsoft.Extensions.Http.Polly to 8.0.8

### DIFF
--- a/HomeBudget.Components.CurrencyRates/HomeBudget.Components.CurrencyRates.csproj
+++ b/HomeBudget.Components.CurrencyRates/HomeBudget.Components.CurrencyRates.csproj
@@ -13,7 +13,7 @@
 		<PackageReference Include="Microsoft.Extensions.Http" Version="8.0.0" />
 		<PackageReference Include="Microsoft.Extensions.Http.Resilience" Version="8.7.0" />
 		<PackageReference Include="Polly" Version="8.4.1" />
-		<PackageReference Include="Microsoft.Extensions.Http.Polly" Version="8.0.7" />
+		<PackageReference Include="Microsoft.Extensions.Http.Polly" Version="8.0.8" />
 		<PackageReference Include="Refit.Newtonsoft.Json" Version="7.1.2" />
 		<PackageReference Include="Refit.HttpClientFactory" Version="7.1.2" />
 		<PackageReference Include="Refit" Version="7.1.2" />


### PR DESCRIPTION
NuKeeper has generated a patch update of `Microsoft.Extensions.Http.Polly` to `8.0.8` from `8.0.7`
`Microsoft.Extensions.Http.Polly 8.0.8` was published at `2024-08-13T12:58:17Z`, 7 days ago

1 project update:
Updated `HomeBudget.Components.CurrencyRates/HomeBudget.Components.CurrencyRates.csproj` to `Microsoft.Extensions.Http.Polly` `8.0.8` from `8.0.7`

[Microsoft.Extensions.Http.Polly 8.0.8 on NuGet.org](https://www.nuget.org/packages/Microsoft.Extensions.Http.Polly/8.0.8)


This is an automated update. Merge only if it passes tests
**NuKeeper**: https://github.com/NuKeeperDotNet/NuKeeper
