### PR TITLE
Automatic update of Microsoft.Data.SqlClient to 5.2.2

### DIFF
--- a/HomeBudget.DataAccess.Dapper/HomeBudget.DataAccess.Dapper.csproj
+++ b/HomeBudget.DataAccess.Dapper/HomeBudget.DataAccess.Dapper.csproj
@@ -8,7 +8,7 @@
 
   <ItemGroup>
     <PackageReference Include="Dapper" Version="2.1.35" />
-    <PackageReference Include="Microsoft.Data.SqlClient" Version="5.2.1" />
+    <PackageReference Include="Microsoft.Data.SqlClient" Version="5.2.2" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.1" />
     <PackageReference Include="Microsoft.Extensions.Options" Version="8.0.2" />
   </ItemGroup>


### PR DESCRIPTION
NuKeeper has generated a patch update of `Microsoft.Data.SqlClient` to `5.2.2` from `5.2.1`
`Microsoft.Data.SqlClient 5.2.2` was published at `2024-08-27T21:01:28Z`, 7 days ago

1 project update:
Updated `HomeBudget.DataAccess.Dapper/HomeBudget.DataAccess.Dapper.csproj` to `Microsoft.Data.SqlClient` `5.2.2` from `5.2.1`

[Microsoft.Data.SqlClient 5.2.2 on NuGet.org](https://www.nuget.org/packages/Microsoft.Data.SqlClient/5.2.2)


This is an automated update. Merge only if it passes tests
**NuKeeper**: https://github.com/NuKeeperDotNet/NuKeeper
