### PR TITLE
Automatic update of RestSharp to 112.0.0

### DIFF
--- a/HomeBudget.Components.IntegrationTests/HomeBudget.Components.IntegrationTests.csproj
+++ b/HomeBudget.Components.IntegrationTests/HomeBudget.Components.IntegrationTests.csproj
@@ -22,7 +22,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="RestSharp" Version="111.4.1" />
+    <PackageReference Include="RestSharp" Version="112.0.0" />
     <PackageReference Include="Testcontainers.Redis" Version="3.9.0" />
     <PackageReference Include="Testcontainers.MsSql" Version="3.9.0" />
     <PackageReference Include="Testcontainers" Version="3.9.0" />


### PR DESCRIPTION
NuKeeper has generated a major update of `RestSharp` to `112.0.0` from `111.4.1`
`RestSharp 112.0.0` was published at `2024-08-29T19:06:42Z`, 7 days ago

1 project update:
Updated `HomeBudget.Components.IntegrationTests/HomeBudget.Components.IntegrationTests.csproj` to `RestSharp` `112.0.0` from `111.4.1`

[RestSharp 112.0.0 on NuGet.org](https://www.nuget.org/packages/RestSharp/112.0.0)


This is an automated update. Merge only if it passes tests
**NuKeeper**: https://github.com/NuKeeperDotNet/NuKeeper
