### PR TITLE
Automatic update of AspNetCore.HealthChecks.UI to 8.0.2

### DIFF
--- a/HomeBudget.Rates.Api/HomeBudget.Rates.Api.csproj
+++ b/HomeBudget.Rates.Api/HomeBudget.Rates.Api.csproj
@@ -12,7 +12,7 @@
     <PackageReference Include="AspNetCore.HealthChecks.Prometheus.Metrics" Version="8.0.1" />
     <PackageReference Include="AspNetCore.HealthChecks.Redis" Version="8.0.1" />
     <PackageReference Include="AspNetCore.HealthChecks.SqlServer" Version="8.0.2" />
-    <PackageReference Include="AspNetCore.HealthChecks.UI" Version="8.0.1" />
+    <PackageReference Include="AspNetCore.HealthChecks.UI" Version="8.0.2" />
     <PackageReference Include="AspNetCore.HealthChecks.UI.Client" Version="8.0.1" />
     <PackageReference Include="AspNetCore.HealthChecks.UI.InMemory.Storage" Version="8.0.1" />
     <PackageReference Include="Azure.Identity" Version="1.12.0" />


### PR DESCRIPTION
NuKeeper has generated a patch update of `AspNetCore.HealthChecks.UI` to `8.0.2` from `8.0.1`
`AspNetCore.HealthChecks.UI 8.0.2` was published at `2024-08-29T17:20:43Z`, 7 days ago

1 project update:
Updated `HomeBudget.Rates.Api/HomeBudget.Rates.Api.csproj` to `AspNetCore.HealthChecks.UI` `8.0.2` from `8.0.1`

[AspNetCore.HealthChecks.UI 8.0.2 on NuGet.org](https://www.nuget.org/packages/AspNetCore.HealthChecks.UI/8.0.2)


This is an automated update. Merge only if it passes tests
**NuKeeper**: https://github.com/NuKeeperDotNet/NuKeeper
