### PR TITLE
Automatic update of Datadog.Trace.Bundle to 3.2.0

### DIFF
--- a/HomeBudget.Rates.Api/HomeBudget.Rates.Api.csproj
+++ b/HomeBudget.Rates.Api/HomeBudget.Rates.Api.csproj
@@ -16,7 +16,7 @@
     <PackageReference Include="AspNetCore.HealthChecks.UI.Client" Version="8.0.1" />
     <PackageReference Include="AspNetCore.HealthChecks.UI.InMemory.Storage" Version="8.0.1" />
     <PackageReference Include="Azure.Identity" Version="1.12.0" />
-    <PackageReference Include="Datadog.Trace.Bundle" Version="2.57.0" />
+    <PackageReference Include="Datadog.Trace.Bundle" Version="3.2.0" />
     <PackageReference Include="Elastic.Apm.SerilogEnricher" Version="8.11.1" />
     <PackageReference Include="Elastic.Serilog.Sinks" Version="8.11.1" />
     <PackageReference Include="FluentValidation.AspNetCore" Version="11.3.0" />


### PR DESCRIPTION
NuKeeper has generated a major update of `Datadog.Trace.Bundle` to `3.2.0` from `2.57.0`
`Datadog.Trace.Bundle 3.2.0` was published at `2024-09-02T13:13:04Z`, 7 days ago

1 project update:
Updated `HomeBudget.Rates.Api/HomeBudget.Rates.Api.csproj` to `Datadog.Trace.Bundle` `3.2.0` from `2.57.0`

[Datadog.Trace.Bundle 3.2.0 on NuGet.org](https://www.nuget.org/packages/Datadog.Trace.Bundle/3.2.0)


This is an automated update. Merge only if it passes tests
**NuKeeper**: https://github.com/NuKeeperDotNet/NuKeeper
