### PR TITLE
Automatic update of StackExchange.Redis to 2.8.16

### DIFF
--- a/HomeBudget.Rates.Api/HomeBudget.Rates.Api.csproj
+++ b/HomeBudget.Rates.Api/HomeBudget.Rates.Api.csproj
@@ -43,7 +43,7 @@
     <PackageReference Include="Serilog.Extensions.Logging" Version="8.0.0" />
     <PackageReference Include="Serilog.Formatting.Compact" Version="3.0.0" />
     <PackageReference Include="Serilog.Sinks.Debug" Version="3.0.0" />
-    <PackageReference Include="StackExchange.Redis" Version="2.8.12" />
+    <PackageReference Include="StackExchange.Redis" Version="2.8.16" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.7.3" />
     <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="8.0.2" />
   </ItemGroup>


### PR DESCRIPTION
NuKeeper has generated a patch update of `StackExchange.Redis` to `2.8.16` from `2.8.12`
`StackExchange.Redis 2.8.16` was published at `2024-09-10T16:14:42Z`, 7 days ago

1 project update:
Updated `HomeBudget.Rates.Api/HomeBudget.Rates.Api.csproj` to `StackExchange.Redis` `2.8.16` from `2.8.12`

[StackExchange.Redis 2.8.16 on NuGet.org](https://www.nuget.org/packages/StackExchange.Redis/2.8.16)


This is an automated update. Merge only if it passes tests
**NuKeeper**: https://github.com/NuKeeperDotNet/NuKeeper
