### PR TITLE
Automatic update of FluentValidation.DependencyInjectionExtensions to 11.10.0

### DIFF
--- a/HomeBudget.Rates.Api/HomeBudget.Rates.Api.csproj
+++ b/HomeBudget.Rates.Api/HomeBudget.Rates.Api.csproj
@@ -20,7 +20,7 @@
     <PackageReference Include="Elastic.Apm.SerilogEnricher" Version="8.11.1" />
     <PackageReference Include="Elastic.Serilog.Sinks" Version="8.11.1" />
     <PackageReference Include="FluentValidation.AspNetCore" Version="11.3.0" />
-    <PackageReference Include="FluentValidation.DependencyInjectionExtensions" Version="11.9.2" />
+    <PackageReference Include="FluentValidation.DependencyInjectionExtensions" Version="11.10.0" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.8" />
     <PackageReference Include="Microsoft.AspNetCore.HeaderPropagation" Version="8.0.8" />
     <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.21.0" />


### PR DESCRIPTION
NuKeeper has generated a minor update of `FluentValidation.DependencyInjectionExtensions` to `11.10.0` from `11.9.2`
`FluentValidation.DependencyInjectionExtensions 11.10.0` was published at `2024-09-15T11:41:12Z`, 7 days ago

1 project update:
Updated `HomeBudget.Rates.Api/HomeBudget.Rates.Api.csproj` to `FluentValidation.DependencyInjectionExtensions` `11.10.0` from `11.9.2`

[FluentValidation.DependencyInjectionExtensions 11.10.0 on NuGet.org](https://www.nuget.org/packages/FluentValidation.DependencyInjectionExtensions/11.10.0)


This is an automated update. Merge only if it passes tests
**NuKeeper**: https://github.com/NuKeeperDotNet/NuKeeper
