### PR TITLE
Automatic update of Refit.Newtonsoft.Json to 7.2.1

### DIFF
--- a/HomeBudget.Components.CurrencyRates/HomeBudget.Components.CurrencyRates.csproj
+++ b/HomeBudget.Components.CurrencyRates/HomeBudget.Components.CurrencyRates.csproj
@@ -14,7 +14,7 @@
 		<PackageReference Include="Microsoft.Extensions.Http.Resilience" Version="8.9.1" />
 		<PackageReference Include="Polly" Version="8.4.1" />
 		<PackageReference Include="Microsoft.Extensions.Http.Polly" Version="8.0.8" />
-		<PackageReference Include="Refit.Newtonsoft.Json" Version="7.1.2" />
+		<PackageReference Include="Refit.Newtonsoft.Json" Version="7.2.1" />
 		<PackageReference Include="Refit.HttpClientFactory" Version="7.1.2" />
 		<PackageReference Include="Refit" Version="7.1.2" />
 		<PackageReference Include="System.Text.Json" Version="8.0.4" />


### PR DESCRIPTION
NuKeeper has generated a minor update of `Refit.Newtonsoft.Json` to `7.2.1` from `7.1.2`
`Refit.Newtonsoft.Json 7.2.1` was published at `2024-09-19T00:29:06Z`, 7 days ago

1 project update:
Updated `HomeBudget.Components.CurrencyRates/HomeBudget.Components.CurrencyRates.csproj` to `Refit.Newtonsoft.Json` `7.2.1` from `7.1.2`

[Refit.Newtonsoft.Json 7.2.1 on NuGet.org](https://www.nuget.org/packages/Refit.Newtonsoft.Json/7.2.1)


This is an automated update. Merge only if it passes tests
**NuKeeper**: https://github.com/NuKeeperDotNet/NuKeeper
