### PR TITLE
Automatic update of System.IdentityModel.Tokens.Jwt to 8.1.0

### DIFF
--- a/HomeBudget.Rates.Api/HomeBudget.Rates.Api.csproj
+++ b/HomeBudget.Rates.Api/HomeBudget.Rates.Api.csproj
@@ -45,7 +45,7 @@
     <PackageReference Include="Serilog.Sinks.Debug" Version="3.0.0" />
     <PackageReference Include="StackExchange.Redis" Version="2.8.16" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.7.3" />
-    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="8.0.2" />
+    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="8.1.0" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
NuKeeper has generated a minor update of `System.IdentityModel.Tokens.Jwt` to `8.1.0` from `8.0.2`
`System.IdentityModel.Tokens.Jwt 8.1.0` was published at `2024-09-24T15:23:34Z`, 7 days ago

1 project update:
Updated `HomeBudget.Rates.Api/HomeBudget.Rates.Api.csproj` to `System.IdentityModel.Tokens.Jwt` `8.1.0` from `8.0.2`

[System.IdentityModel.Tokens.Jwt 8.1.0 on NuGet.org](https://www.nuget.org/packages/System.IdentityModel.Tokens.Jwt/8.1.0)


This is an automated update. Merge only if it passes tests
**NuKeeper**: https://github.com/NuKeeperDotNet/NuKeeper
