### PR TITLE
Automatic update of Azure.Identity to 1.12.1

### DIFF
--- a/HomeBudget.Rates.Api/HomeBudget.Rates.Api.csproj
+++ b/HomeBudget.Rates.Api/HomeBudget.Rates.Api.csproj
@@ -15,7 +15,7 @@
     <PackageReference Include="AspNetCore.HealthChecks.UI" Version="8.0.2" />
     <PackageReference Include="AspNetCore.HealthChecks.UI.Client" Version="8.0.1" />
     <PackageReference Include="AspNetCore.HealthChecks.UI.InMemory.Storage" Version="8.0.1" />
-    <PackageReference Include="Azure.Identity" Version="1.12.0" />
+    <PackageReference Include="Azure.Identity" Version="1.12.1" />
     <PackageReference Include="Datadog.Trace.Bundle" Version="3.3.1" />
     <PackageReference Include="Elastic.Apm.SerilogEnricher" Version="8.11.1" />
     <PackageReference Include="Elastic.Serilog.Sinks" Version="8.11.1" />


### PR DESCRIPTION
NuKeeper has generated a patch update of `Azure.Identity` to `1.12.1` from `1.12.0`
`Azure.Identity 1.12.1` was published at `2024-09-26T21:35:00Z`, 7 days ago

1 project update:
Updated `HomeBudget.Rates.Api/HomeBudget.Rates.Api.csproj` to `Azure.Identity` `1.12.1` from `1.12.0`

[Azure.Identity 1.12.1 on NuGet.org](https://www.nuget.org/packages/Azure.Identity/1.12.1)


This is an automated update. Merge only if it passes tests
**NuKeeper**: https://github.com/NuKeeperDotNet/NuKeeper
