### PR TITLE
Automatic update of Polly to 8.4.2

### DIFF
--- a/HomeBudget.Components.CurrencyRates/HomeBudget.Components.CurrencyRates.csproj
+++ b/HomeBudget.Components.CurrencyRates/HomeBudget.Components.CurrencyRates.csproj
@@ -12,7 +12,7 @@
 		<PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.1" />
 		<PackageReference Include="Microsoft.Extensions.Http" Version="8.0.0" />
 		<PackageReference Include="Microsoft.Extensions.Http.Resilience" Version="8.9.1" />
-		<PackageReference Include="Polly" Version="8.4.1" />
+		<PackageReference Include="Polly" Version="8.4.2" />
 		<PackageReference Include="Microsoft.Extensions.Http.Polly" Version="8.0.8" />
 		<PackageReference Include="Refit.Newtonsoft.Json" Version="7.2.1" />
 		<PackageReference Include="Refit.HttpClientFactory" Version="7.2.1" />


### PR DESCRIPTION
NuKeeper has generated a patch update of `Polly` to `8.4.2` from `8.4.1`
`Polly 8.4.2` was published at `2024-09-26T16:42:49Z`, 7 days ago

1 project update:
Updated `HomeBudget.Components.CurrencyRates/HomeBudget.Components.CurrencyRates.csproj` to `Polly` `8.4.2` from `8.4.1`

[Polly 8.4.2 on NuGet.org](https://www.nuget.org/packages/Polly/8.4.2)


This is an automated update. Merge only if it passes tests
**NuKeeper**: https://github.com/NuKeeperDotNet/NuKeeper
