### PR TITLE
Automatic update of Elastic.Serilog.Sinks to 8.12.1

### DIFF
--- a/HomeBudget.Rates.Api/HomeBudget.Rates.Api.csproj
+++ b/HomeBudget.Rates.Api/HomeBudget.Rates.Api.csproj
@@ -18,7 +18,7 @@
     <PackageReference Include="Azure.Identity" Version="1.12.1" />
     <PackageReference Include="Datadog.Trace.Bundle" Version="3.3.1" />
     <PackageReference Include="Elastic.Apm.SerilogEnricher" Version="8.11.1" />
-    <PackageReference Include="Elastic.Serilog.Sinks" Version="8.11.1" />
+    <PackageReference Include="Elastic.Serilog.Sinks" Version="8.12.1" />
     <PackageReference Include="FluentValidation.AspNetCore" Version="11.3.0" />
     <PackageReference Include="FluentValidation.DependencyInjectionExtensions" Version="11.10.0" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.8" />


### PR DESCRIPTION
NuKeeper has generated a minor update of `Elastic.Serilog.Sinks` to `8.12.1` from `8.11.1`
`Elastic.Serilog.Sinks 8.12.1` was published at `2024-10-03T14:50:25Z`, 7 days ago

1 project update:
Updated `HomeBudget.Rates.Api/HomeBudget.Rates.Api.csproj` to `Elastic.Serilog.Sinks` `8.12.1` from `8.11.1`

[Elastic.Serilog.Sinks 8.12.1 on NuGet.org](https://www.nuget.org/packages/Elastic.Serilog.Sinks/8.12.1)


This is an automated update. Merge only if it passes tests
**NuKeeper**: https://github.com/NuKeeperDotNet/NuKeeper
