### PR TITLE
Automatic update of Testcontainers.Redis to 4.0.0

### DIFF
--- a/HomeBudget.Components.IntegrationTests/HomeBudget.Components.IntegrationTests.csproj
+++ b/HomeBudget.Components.IntegrationTests/HomeBudget.Components.IntegrationTests.csproj
@@ -23,7 +23,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="RestSharp" Version="112.1.0" />
-    <PackageReference Include="Testcontainers.Redis" Version="3.10.0" />
+    <PackageReference Include="Testcontainers.Redis" Version="4.0.0" />
     <PackageReference Include="Testcontainers.MsSql" Version="3.10.0" />
     <PackageReference Include="Testcontainers" Version="3.10.0" />
   </ItemGroup>


### PR DESCRIPTION
NuKeeper has generated a major update of `Testcontainers.Redis` to `4.0.0` from `3.10.0`
`Testcontainers.Redis 4.0.0` was published at `2024-11-01T09:08:33Z`, 7 days ago

1 project update:
Updated `HomeBudget.Components.IntegrationTests/HomeBudget.Components.IntegrationTests.csproj` to `Testcontainers.Redis` `4.0.0` from `3.10.0`

[Testcontainers.Redis 4.0.0 on NuGet.org](https://www.nuget.org/packages/Testcontainers.Redis/4.0.0)


This is an automated update. Merge only if it passes tests
**NuKeeper**: https://github.com/NuKeeperDotNet/NuKeeper
