### PR TITLE
Automatic update of Refit to 8.0.0

### DIFF
--- a/HomeBudget.Components.CurrencyRates/HomeBudget.Components.CurrencyRates.csproj
+++ b/HomeBudget.Components.CurrencyRates/HomeBudget.Components.CurrencyRates.csproj
@@ -16,7 +16,7 @@
 		<PackageReference Include="Microsoft.Extensions.Http.Polly" Version="8.0.10" />
 		<PackageReference Include="Refit.Newtonsoft.Json" Version="7.2.1" />
 		<PackageReference Include="Refit.HttpClientFactory" Version="7.2.1" />
-		<PackageReference Include="Refit" Version="7.2.1" />
+		<PackageReference Include="Refit" Version="8.0.0" />
 		<PackageReference Include="System.Text.Json" Version="8.0.5" />
 	</ItemGroup>
 


### PR DESCRIPTION
NuKeeper has generated a major update of `Refit` to `8.0.0` from `7.2.1`
`Refit 8.0.0` was published at `2024-11-03T03:19:48Z`, 7 days ago

1 project update:
Updated `HomeBudget.Components.CurrencyRates/HomeBudget.Components.CurrencyRates.csproj` to `Refit` `8.0.0` from `7.2.1`

[Refit 8.0.0 on NuGet.org](https://www.nuget.org/packages/Refit/8.0.0)


This is an automated update. Merge only if it passes tests
**NuKeeper**: https://github.com/NuKeeperDotNet/NuKeeper
