### PR TITLE
Automatic update of Datadog.Trace.Bundle to 3.5.0

### DIFF
--- a/HomeBudget.Rates.Api/HomeBudget.Rates.Api.csproj
+++ b/HomeBudget.Rates.Api/HomeBudget.Rates.Api.csproj
@@ -16,7 +16,7 @@
     <PackageReference Include="AspNetCore.HealthChecks.UI.Client" Version="8.0.1" />
     <PackageReference Include="AspNetCore.HealthChecks.UI.InMemory.Storage" Version="8.0.1" />
     <PackageReference Include="Azure.Identity" Version="1.13.1" />
-    <PackageReference Include="Datadog.Trace.Bundle" Version="3.4.1" />
+    <PackageReference Include="Datadog.Trace.Bundle" Version="3.5.0" />
     <PackageReference Include="Elastic.Apm.SerilogEnricher" Version="8.12.2" />
     <PackageReference Include="Elastic.Serilog.Sinks" Version="8.12.2" />
     <PackageReference Include="FluentValidation.AspNetCore" Version="11.3.0" />


### PR DESCRIPTION
NuKeeper has generated a minor update of `Datadog.Trace.Bundle` to `3.5.0` from `3.4.1`
`Datadog.Trace.Bundle 3.5.0` was published at `2024-11-06T10:51:38Z`, 7 days ago

1 project update:
Updated `HomeBudget.Rates.Api/HomeBudget.Rates.Api.csproj` to `Datadog.Trace.Bundle` `3.5.0` from `3.4.1`

[Datadog.Trace.Bundle 3.5.0 on NuGet.org](https://www.nuget.org/packages/Datadog.Trace.Bundle/3.5.0)


This is an automated update. Merge only if it passes tests
**NuKeeper**: https://github.com/NuKeeperDotNet/NuKeeper
