### PR TITLE
Automatic update of Microsoft.Extensions.DependencyInjection.Abstractions to 9.0.0

### DIFF
--- a/HomeBudget.Components.CurrencyRates/HomeBudget.Components.CurrencyRates.csproj
+++ b/HomeBudget.Components.CurrencyRates/HomeBudget.Components.CurrencyRates.csproj
@@ -9,7 +9,7 @@
 	<ItemGroup>
 		<PackageReference Include="AutoMapper" Version="13.0.1" />
 		<PackageReference Include="MediatR" Version="12.4.1" />
-		<PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.2" />
+		<PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="9.0.0" />
 		<PackageReference Include="Microsoft.Extensions.Http" Version="8.0.1" />
 		<PackageReference Include="Microsoft.Extensions.Http.Resilience" Version="8.10.0" />
 		<PackageReference Include="Polly" Version="8.4.2" />

--- a/HomeBudget.Core/HomeBudget.Core.csproj
+++ b/HomeBudget.Core/HomeBudget.Core.csproj
@@ -7,7 +7,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.2" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.2" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="9.0.0" />
     <PackageReference Include="Microsoft.Extensions.Options" Version="8.0.2" />
     <PackageReference Include="StackExchange.Redis" Version="2.8.16" />
   </ItemGroup>


### PR DESCRIPTION
NuKeeper has generated a major update of `Microsoft.Extensions.DependencyInjection.Abstractions` to `9.0.0` from `8.0.2`
`Microsoft.Extensions.DependencyInjection.Abstractions 9.0.0` was published at `2024-11-12T18:13:44Z`, 7 days ago

2 project updates:
Updated `HomeBudget.Core/HomeBudget.Core.csproj` to `Microsoft.Extensions.DependencyInjection.Abstractions` `9.0.0` from `8.0.2`
Updated `HomeBudget.Components.CurrencyRates/HomeBudget.Components.CurrencyRates.csproj` to `Microsoft.Extensions.DependencyInjection.Abstractions` `9.0.0` from `8.0.2`

[Microsoft.Extensions.DependencyInjection.Abstractions 9.0.0 on NuGet.org](https://www.nuget.org/packages/Microsoft.Extensions.DependencyInjection.Abstractions/9.0.0)


This is an automated update. Merge only if it passes tests
**NuKeeper**: https://github.com/NuKeeperDotNet/NuKeeper
