### PR TITLE
Automatic update of Serilog.Extensions.Logging to 9.0.0

### DIFF
--- a/HomeBudget.Rates.Api/HomeBudget.Rates.Api.csproj
+++ b/HomeBudget.Rates.Api/HomeBudget.Rates.Api.csproj
@@ -41,7 +41,7 @@
     <PackageReference Include="Serilog.Enrichers.Span" Version="3.1.0" />
     <PackageReference Include="Serilog.Enrichers.Thread" Version="4.0.0" />
     <PackageReference Include="Serilog.Exceptions" Version="8.4.0" />
-    <PackageReference Include="Serilog.Extensions.Logging" Version="8.0.0" />
+    <PackageReference Include="Serilog.Extensions.Logging" Version="9.0.0" />
     <PackageReference Include="Serilog.Formatting.Compact" Version="3.0.0" />
     <PackageReference Include="Serilog.Sinks.Debug" Version="3.0.0" />
     <PackageReference Include="StackExchange.Redis" Version="2.8.22" />


### PR DESCRIPTION
NuKeeper has generated a major update of `Serilog.Extensions.Logging` to `9.0.0` from `8.0.0`
`Serilog.Extensions.Logging 9.0.0` was published at `2024-12-09T00:19:22Z`, 7 days ago

1 project update:
Updated `HomeBudget.Rates.Api/HomeBudget.Rates.Api.csproj` to `Serilog.Extensions.Logging` `9.0.0` from `8.0.0`

[Serilog.Extensions.Logging 9.0.0 on NuGet.org](https://www.nuget.org/packages/Serilog.Extensions.Logging/9.0.0)


This is an automated update. Merge only if it passes tests
**NuKeeper**: https://github.com/NuKeeperDotNet/NuKeeper
