### PR TITLE
Automatic update of Testcontainers to 4.1.0

### DIFF
--- a/HomeBudget.Components.IntegrationTests/HomeBudget.Components.IntegrationTests.csproj
+++ b/HomeBudget.Components.IntegrationTests/HomeBudget.Components.IntegrationTests.csproj
@@ -26,7 +26,7 @@
     <PackageReference Include="RestSharp" Version="112.1.0" />
     <PackageReference Include="Testcontainers.Redis" Version="4.0.0" />
     <PackageReference Include="Testcontainers.MsSql" Version="4.0.0" />
-    <PackageReference Include="Testcontainers" Version="4.0.0" />
+    <PackageReference Include="Testcontainers" Version="4.1.0" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
NuKeeper has generated a minor update of `Testcontainers` to `4.1.0` from `4.0.0`
`Testcontainers 4.1.0` was published at `2024-12-09T19:02:03Z`, 7 days ago

1 project update:
Updated `HomeBudget.Components.IntegrationTests/HomeBudget.Components.IntegrationTests.csproj` to `Testcontainers` `4.1.0` from `4.0.0`

[Testcontainers 4.1.0 on NuGet.org](https://www.nuget.org/packages/Testcontainers/4.1.0)


This is an automated update. Merge only if it passes tests
**NuKeeper**: https://github.com/NuKeeperDotNet/NuKeeper
