### PR TITLE
Automatic update of Swashbuckle.AspNetCore to 7.2.0

### DIFF
--- a/HomeBudget.Rates.Api/HomeBudget.Rates.Api.csproj
+++ b/HomeBudget.Rates.Api/HomeBudget.Rates.Api.csproj
@@ -45,7 +45,7 @@
     <PackageReference Include="Serilog.Formatting.Compact" Version="3.0.0" />
     <PackageReference Include="Serilog.Sinks.Debug" Version="3.0.0" />
     <PackageReference Include="StackExchange.Redis" Version="2.8.22" />
-    <PackageReference Include="Swashbuckle.AspNetCore" Version="7.1.0" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="7.2.0" />
     <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="8.3.0" />
   </ItemGroup>
 


### PR DESCRIPTION
NuKeeper has generated a minor update of `Swashbuckle.AspNetCore` to `7.2.0` from `7.1.0`
`Swashbuckle.AspNetCore 7.2.0` was published at `2024-12-10T17:22:33Z`, 7 days ago

1 project update:
Updated `HomeBudget.Rates.Api/HomeBudget.Rates.Api.csproj` to `Swashbuckle.AspNetCore` `7.2.0` from `7.1.0`

[Swashbuckle.AspNetCore 7.2.0 on NuGet.org](https://www.nuget.org/packages/Swashbuckle.AspNetCore/7.2.0)


This is an automated update. Merge only if it passes tests
**NuKeeper**: https://github.com/NuKeeperDotNet/NuKeeper
