### PR TITLE
Automatic update of SonarAnalyzer.CSharp to 10.4.0.108396

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -5,6 +5,6 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.118" PrivateAssets="all" Condition="$(MSBuildProjectExtension) == '.csproj'" />
-    <PackageReference Include="SonarAnalyzer.CSharp" Version="10.3.0.106239" PrivateAssets="all" Condition="$(MSBuildProjectExtension) == '.csproj'" />
+    <PackageReference Include="SonarAnalyzer.CSharp" Version="10.4.0.108396" PrivateAssets="all" Condition="$(MSBuildProjectExtension) == '.csproj'" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
NuKeeper has generated a minor update of `SonarAnalyzer.CSharp` to `10.4.0.108396` from `10.3.0.106239`
`SonarAnalyzer.CSharp 10.4.0.108396` was published at `2024-12-18T10:15:10Z`, 7 days ago

1 project update:
Updated `Directory.Build.props` to `SonarAnalyzer.CSharp` `10.4.0.108396` from `10.3.0.106239`

[SonarAnalyzer.CSharp 10.4.0.108396 on NuGet.org](https://www.nuget.org/packages/SonarAnalyzer.CSharp/10.4.0.108396)


This is an automated update. Merge only if it passes tests
**NuKeeper**: https://github.com/NuKeeperDotNet/NuKeeper
