### PR TITLE
Automatic update of AspNetCore.HealthChecks.Prometheus.Metrics to 9.0.0

### DIFF
--- a/HomeBudget.Rates.Api/HomeBudget.Rates.Api.csproj
+++ b/HomeBudget.Rates.Api/HomeBudget.Rates.Api.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AspNetCore.HealthChecks.Prometheus.Metrics" Version="8.0.1" />
+    <PackageReference Include="AspNetCore.HealthChecks.Prometheus.Metrics" Version="9.0.0" />
     <PackageReference Include="AspNetCore.HealthChecks.Redis" Version="8.0.1" />
     <PackageReference Include="AspNetCore.HealthChecks.SqlServer" Version="8.0.2" />
     <PackageReference Include="AspNetCore.HealthChecks.UI" Version="8.0.2" />


### PR DESCRIPTION
NuKeeper has generated a major update of `AspNetCore.HealthChecks.Prometheus.Metrics` to `9.0.0` from `8.0.1`
`AspNetCore.HealthChecks.Prometheus.Metrics 9.0.0` was published at `2024-12-19T10:52:41Z`, 7 days ago

1 project update:
Updated `HomeBudget.Rates.Api/HomeBudget.Rates.Api.csproj` to `AspNetCore.HealthChecks.Prometheus.Metrics` `9.0.0` from `8.0.1`

[AspNetCore.HealthChecks.Prometheus.Metrics 9.0.0 on NuGet.org](https://www.nuget.org/packages/AspNetCore.HealthChecks.Prometheus.Metrics/9.0.0)


This is an automated update. Merge only if it passes tests
**NuKeeper**: https://github.com/NuKeeperDotNet/NuKeeper
