### PR TITLE
Automatic update of AspNetCore.HealthChecks.SqlServer to 9.0.0

### DIFF
--- a/HomeBudget.Rates.Api/HomeBudget.Rates.Api.csproj
+++ b/HomeBudget.Rates.Api/HomeBudget.Rates.Api.csproj
@@ -11,7 +11,7 @@
   <ItemGroup>
     <PackageReference Include="AspNetCore.HealthChecks.Prometheus.Metrics" Version="8.0.1" />
     <PackageReference Include="AspNetCore.HealthChecks.Redis" Version="8.0.1" />
-    <PackageReference Include="AspNetCore.HealthChecks.SqlServer" Version="8.0.2" />
+    <PackageReference Include="AspNetCore.HealthChecks.SqlServer" Version="9.0.0" />
     <PackageReference Include="AspNetCore.HealthChecks.UI" Version="8.0.2" />
     <PackageReference Include="AspNetCore.HealthChecks.UI.Client" Version="8.0.1" />
     <PackageReference Include="AspNetCore.HealthChecks.UI.InMemory.Storage" Version="8.0.1" />


### PR DESCRIPTION
NuKeeper has generated a major update of `AspNetCore.HealthChecks.SqlServer` to `9.0.0` from `8.0.2`
`AspNetCore.HealthChecks.SqlServer 9.0.0` was published at `2024-12-19T10:53:08Z`, 7 days ago

1 project update:
Updated `HomeBudget.Rates.Api/HomeBudget.Rates.Api.csproj` to `AspNetCore.HealthChecks.SqlServer` `9.0.0` from `8.0.2`

[AspNetCore.HealthChecks.SqlServer 9.0.0 on NuGet.org](https://www.nuget.org/packages/AspNetCore.HealthChecks.SqlServer/9.0.0)


This is an automated update. Merge only if it passes tests
**NuKeeper**: https://github.com/NuKeeperDotNet/NuKeeper
