### PR TITLE
Automatic update of AspNetCore.HealthChecks.UI.Client to 9.0.0

### DIFF
--- a/HomeBudget.Rates.Api/HomeBudget.Rates.Api.csproj
+++ b/HomeBudget.Rates.Api/HomeBudget.Rates.Api.csproj
@@ -13,7 +13,7 @@
     <PackageReference Include="AspNetCore.HealthChecks.Redis" Version="8.0.1" />
     <PackageReference Include="AspNetCore.HealthChecks.SqlServer" Version="8.0.2" />
     <PackageReference Include="AspNetCore.HealthChecks.UI" Version="8.0.2" />
-    <PackageReference Include="AspNetCore.HealthChecks.UI.Client" Version="8.0.1" />
+    <PackageReference Include="AspNetCore.HealthChecks.UI.Client" Version="9.0.0" />
     <PackageReference Include="AspNetCore.HealthChecks.UI.InMemory.Storage" Version="8.0.1" />
     <PackageReference Include="Azure.Identity" Version="1.13.1" />
     <PackageReference Include="Datadog.Trace.Bundle" Version="3.7.0" />


### PR DESCRIPTION
NuKeeper has generated a major update of `AspNetCore.HealthChecks.UI.Client` to `9.0.0` from `8.0.1`
`AspNetCore.HealthChecks.UI.Client 9.0.0` was published at `2024-12-19T10:53:14Z`, 7 days ago

1 project update:
Updated `HomeBudget.Rates.Api/HomeBudget.Rates.Api.csproj` to `AspNetCore.HealthChecks.UI.Client` `9.0.0` from `8.0.1`

[AspNetCore.HealthChecks.UI.Client 9.0.0 on NuGet.org](https://www.nuget.org/packages/AspNetCore.HealthChecks.UI.Client/9.0.0)


This is an automated update. Merge only if it passes tests
**NuKeeper**: https://github.com/NuKeeperDotNet/NuKeeper
