### PR TITLE
Automatic update of NUnit to 4.3.2

### DIFF
--- a/HomeBudget.Components.CurrencyRates.Tests/HomeBudget.Components.CurrencyRates.Tests.csproj
+++ b/HomeBudget.Components.CurrencyRates.Tests/HomeBudget.Components.CurrencyRates.Tests.csproj
@@ -11,7 +11,7 @@
     <PackageReference Include="FluentAssertions" Version="7.0.0" />
     <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="9.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
-    <PackageReference Include="NUnit" Version="4.3.0" />
+    <PackageReference Include="NUnit" Version="4.3.2" />
     <PackageReference Include="Moq" Version="4.20.72" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.6.0" />
   </ItemGroup>

--- a/HomeBudget.Components.IntegrationTests/HomeBudget.Components.IntegrationTests.csproj
+++ b/HomeBudget.Components.IntegrationTests/HomeBudget.Components.IntegrationTests.csproj
@@ -12,7 +12,7 @@
     <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="9.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
-    <PackageReference Include="NUnit" Version="4.3.0" />
+    <PackageReference Include="NUnit" Version="4.3.2" />
     <PackageReference Include="Moq" Version="4.20.72" />
     <PackageReference Include="NUnit.Analyzers" Version="4.5.0">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/HomeBudget.Rates.Api.Tests/HomeBudget.Rates.Api.Tests.csproj
+++ b/HomeBudget.Rates.Api.Tests/HomeBudget.Rates.Api.Tests.csproj
@@ -17,7 +17,7 @@
     </PackageReference>
     <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="9.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
-    <PackageReference Include="NUnit" Version="4.3.0" />
+    <PackageReference Include="NUnit" Version="4.3.2" />
     <PackageReference Include="NUnit.Analyzers" Version="4.5.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>


### PR DESCRIPTION
NuKeeper has generated a patch update of `NUnit` to `4.3.2` from `4.3.0`
`NUnit 4.3.2` was published at `2024-12-28T21:29:14Z`, 7 days ago

3 project updates:
Updated `HomeBudget.Components.IntegrationTests/HomeBudget.Components.IntegrationTests.csproj` to `NUnit` `4.3.2` from `4.3.0`
Updated `HomeBudget.Rates.Api.Tests/HomeBudget.Rates.Api.Tests.csproj` to `NUnit` `4.3.2` from `4.3.0`
Updated `HomeBudget.Components.CurrencyRates.Tests/HomeBudget.Components.CurrencyRates.Tests.csproj` to `NUnit` `4.3.2` from `4.3.0`

[NUnit 4.3.2 on NuGet.org](https://www.nuget.org/packages/NUnit/4.3.2)


This is an automated update. Merge only if it passes tests
**NuKeeper**: https://github.com/NuKeeperDotNet/NuKeeper
