### PR TITLE
Automatic update of coverlet.collector to 6.0.3

### DIFF
--- a/HomeBudget.Rates.Api.Tests/HomeBudget.Rates.Api.Tests.csproj
+++ b/HomeBudget.Rates.Api.Tests/HomeBudget.Rates.Api.Tests.csproj
@@ -11,7 +11,7 @@
 
   <ItemGroup>
     <PackageReference Include="AutoMapper" Version="13.0.1" />
-    <PackageReference Include="coverlet.collector" Version="6.0.2">
+    <PackageReference Include="coverlet.collector" Version="6.0.3">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>


### PR DESCRIPTION
NuKeeper has generated a patch update of `coverlet.collector` to `6.0.3` from `6.0.2`
`coverlet.collector 6.0.3` was published at `2024-12-30T23:44:27Z`, 7 days ago

1 project update:
Updated `HomeBudget.Rates.Api.Tests/HomeBudget.Rates.Api.Tests.csproj` to `coverlet.collector` `6.0.3` from `6.0.2`

[coverlet.collector 6.0.3 on NuGet.org](https://www.nuget.org/packages/coverlet.collector/6.0.3)


This is an automated update. Merge only if it passes tests
**NuKeeper**: https://github.com/NuKeeperDotNet/NuKeeper
